### PR TITLE
Add a File ID mapping file, for per-file dicts without modifying the checked file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,10 +97,17 @@ prompted with the following options for every subtoken:
 
     add to (f)ile-specific dictionary
         Add this subtoken to the dictionary associated with the
-        current file. **scspell** identifies unique files by scanning
-        for an embedded ID string, so you will only see this option
-        for files which have such an ID. See `Creating File IDs`
-        for details.
+        current file. You will see this option only for files which
+        have such an embedded ID or which have an entry in the fileid
+        mapping.  See `Creating File IDs`_ for details.
+
+    add to (N)ew file-specific dictionary
+        Create a new file ID for the current file, record the new
+        file ID in the fileid mapping, and add this subtoken to a new
+        file-specific dictionary associated with that file ID.  You will
+        see this option only for files which have neither an embedded ID nor
+        an entry in the fileid mapping, and only if the ``--relative-to``
+	option is given.  See `Creating File IDs`_ for details.
 
     add to (n)atural language dictionary
         Add this subtoken to the natural language dictionary.
@@ -138,12 +145,18 @@ Spell-checking Options
 Creating File IDs
 -----------------
 
-If you would like **scspell** to be able to uniquely identify a file, thus
-enabling the creation of a file-specific dictionary, then you must insert a
-unique ID somewhere in the contents of that file. **scspell** will scan each
-file for a string of the following form::
+If you would like **scspell** to be able to uniquely identify a file,
+thus enabling the creation of a file-specific dictionary, then
+**scspell** must be able to find a file ID to identify both the file
+an the file-specific dictionary.  There are two ways **scspell** can
+find the file ID:
 
-    scspell-id: <unique ID>
+1. The file ID may be embedded directly in the file, using a string of
+   the following form::
+
+      scspell-id: <unique ID>
+
+2. An entry in the fileid mapping file ties a filename to a file ID.
 
 The unique ID must consist only of letters, numbers, underscores, and dashes.
 **scspell** can generate suitable unique ID strings using the ``--gen-id`` option::
@@ -152,6 +165,44 @@ The unique ID must consist only of letters, numbers, underscores, and dashes.
     scspell-id: e497803c-523a-11de-ae42-0017f2ee0f37
 
 (Most likely you will want to place a file's unique ID inside a source code comment.)
+
+During interactive use, the ``(a)dd to dictionary`` -> ``add to (N)ew
+file-specific dictionary`` option will create a new File ID for the
+current file, and add it to the fileid mapping file.
+
+
+--relative-to RELATIVE_TO\ 
+ The filenames stored in the fileid mapping are relative paths.  This
+ option specifies what they're relative to.  If this option is not
+ specified, the fileid mapping will not be consulted, and the ``add to (N)ew
+ file-specific dictionary`` option will not be offered.
+
+
+
+Managing File IDs
+-----------------
+
+These options direct **scspell** to manipulate the fileid mapping.
+(These can all be accomplished by editing the fileid mapping
+manually).  These have no effect on File IDs embedded in files.
+
+--rename-file FROMFILE TOFILE
+   Changes the filename that a File ID maps to.  After renaming a file
+   that has a file-specific dictionary and an entry in the fileid
+   mapping, you can use this option to have the entry "follow" the file.
+
+--delete-files\ 
+   Remove filenames from the fileid mapping.  If it was the only
+   filename for a given File ID, removes the File ID from the mapping and
+   its wordlist from the dictionary.
+
+--merge-fileids FROMID TOID
+  Combines the file-specific dictionaries referenced by the two File
+  IDs.  All words from FROMID's list are moved to TOID's.  The FROMID
+  File ID is removed from the mapping, and any files using it are
+  changed to use TOID.  Either FROMID or TOID may be given as a filename
+  instead, in which case that file's File ID is used for that parameter.
+
 
 Sharing a Dictionary
 --------------------

--- a/scspell.py
+++ b/scspell.py
@@ -79,6 +79,14 @@ def main():
                            renamed TOFILE.  If an entry in the fileid mapping
                            references FROMFILE, it will be modified to reference
                            TOFILE instead.""")
+    dictgroup.add_argument('--delete-files', action='store_true', default=False,
+                           help=
+                           """inform scspell that the listed files have been
+                           deleted.  All fileid mappings for the files
+                           will be removed.  If all uses of that
+                           fileid have been removed, the corresponding
+                           file-private dictionary will be removed.  This will
+                           not spell check the files.""")
 
     parser.add_argument('-D', '--debug', dest='debug', action='store_true',
                         help='print extra debugging information')
@@ -105,6 +113,11 @@ def main():
     elif args.rename_file is not None:
         scspell.rename_file(args.rename_file[0], args.rename_file[1],
                             args.override_filename, args.relative_to)
+    elif args.delete_files:
+        if len(args.files) < 1:
+            parser.error('No files specified for delete')
+        scspell.delete_files(args.files,
+                             args.override_filename, args.relative_to)
     elif len(args.files) < 1:
         parser.error('No files specified')
     else:

--- a/scspell.py
+++ b/scspell.py
@@ -73,6 +73,12 @@ def main():
                            any fileids embedded in to-be-spellchecked files.
                            If your filenames look like fileids, do it by
                            hand.""")
+    dictgroup.add_argument('--rename-file', nargs=2,
+                           metavar=('FROMFILE', 'TOFILE'),
+                           help="""inform scspell that FROMFILE has been
+                           renamed TOFILE.  If an entry in the fileid mapping
+                           references FROMFILE, it will be modified to reference
+                           TOFILE instead.""")
 
     parser.add_argument('-D', '--debug', dest='debug', action='store_true',
                         help='print extra debugging information')
@@ -96,6 +102,9 @@ def main():
     elif args.merge_fileids is not None:
         scspell.merge_fileids(args.merge_fileids[0], args.merge_fileids[1],
                               args.override_filename, args.relative_to)
+    elif args.rename_file is not None:
+        scspell.rename_file(args.rename_file[0], args.rename_file[1],
+                            args.override_filename, args.relative_to)
     elif len(args.files) < 1:
         parser.error('No files specified')
     else:

--- a/scspell.py
+++ b/scspell.py
@@ -35,11 +35,13 @@ def main():
     dictgroup = parser.add_argument_group("dictionary file management")
     spellgroup = parser.add_argument_group("spellcheck control")
 
-    spellgroup.add_argument('--report-only', dest='report', action='store_true',
-                            help='non-interactive report of spelling errors')
-    spellgroup.add_argument('--no-c-escapes', dest='c_escapes',
-                            action='store_false', default=True,
-                            help="treat \\label as label, for e.g. LaTeX")
+    spellgroup.add_argument(
+        '--report-only', dest='report', action='store_true',
+        help='non-interactive report of spelling errors')
+    spellgroup.add_argument(
+        '--no-c-escapes', dest='c_escapes',
+        action='store_false', default=True,
+        help="treat \\label as label, for e.g. LaTeX")
 
     dictgroup.add_argument(
         '--override-dictionary', dest='override_filename',
@@ -58,41 +60,42 @@ def main():
         help='Use file paths relative to here in fileid map.  '
         'This is required to enable use of the fileid map',
         action='store')
-    dictgroup.add_argument('-i', '--gen-id', dest='gen_id', action='store_true',
-                           help='generate a unique file-id string')
-    dictgroup.add_argument('--merge-fileids', nargs=2,
-                           metavar=('TOID', 'FROMID'),
-                           help="""merge these two fileids, keeping
-                           TOID and discarding FROMID.  Combine their
-                           wordlists in the dictionary, and the
-                           filenames associated with them in the
-                           fileid map.  TOID and FROMID may be given
-                           as fileids, or as filenames in which case
-                           the fileids corresponding to those files
-                           are operated on.  Does NOT look for or consider
-                           any fileids embedded in to-be-spellchecked files.
-                           If your filenames look like fileids, do it by
-                           hand.""")
-    dictgroup.add_argument('--rename-file', nargs=2,
-                           metavar=('FROMFILE', 'TOFILE'),
-                           help="""inform scspell that FROMFILE has been
-                           renamed TOFILE.  If an entry in the fileid mapping
-                           references FROMFILE, it will be modified to reference
-                           TOFILE instead.""")
-    dictgroup.add_argument('--delete-files', action='store_true', default=False,
-                           help=
-                           """inform scspell that the listed files have been
-                           deleted.  All fileid mappings for the files
-                           will be removed.  If all uses of that
-                           fileid have been removed, the corresponding
-                           file-private dictionary will be removed.  This will
-                           not spell check the files.""")
+    dictgroup.add_argument(
+        '-i', '--gen-id', dest='gen_id', action='store_true',
+        help='generate a unique file-id string')
+    dictgroup.add_argument(
+        '--merge-fileids', nargs=2,
+        metavar=('TOID', 'FROMID'),
+        help="""merge these two fileids, keeping TOID and discarding FROMID.
+        Combine their wordlists in the dictionary, and the filenames
+        associated with them in the fileid map.  TOID and FROMID may
+        be given as fileids, or as filenames in which case the fileids
+        corresponding to those files are operated on.  Does NOT look
+        for or consider any fileids embedded in to-be-spellchecked
+        files.  If your filenames look like fileids, do it by hand.""")
+    dictgroup.add_argument(
+        '--rename-file', nargs=2,
+        metavar=('FROMFILE', 'TOFILE'),
+        help="""inform scspell that FROMFILE has been renamed TOFILE.
+        If an entry in the fileid mapping references FROMFILE, it will
+        be modified to reference TOFILE instead.""")
+    dictgroup.add_argument(
+        '--delete-files', action='store_true', default=False,
+        help=
+        """inform scspell that the listed files have been deleted.  All fileid
+        mappings for the files will be removed.  If all uses of that
+        fileid have been removed, the corresponding file-private
+        dictionary will be removed.  This will not spell check the
+        files.""")
 
-    parser.add_argument('-D', '--debug', dest='debug', action='store_true',
-                        help='print extra debugging information')
-    parser.add_argument('--version', action='version',
-                        version='%(prog)s ' + scspell.__version__)
-    parser.add_argument('files', nargs='*', help='files to check')
+    parser.add_argument(
+        '-D', '--debug', dest='debug', action='store_true',
+        help='print extra debugging information')
+    parser.add_argument(
+        '--version', action='version',
+        version='%(prog)s ' + scspell.__version__)
+    parser.add_argument(
+        'files', nargs='*', help='files to check')
 
     args = parser.parse_args()
 

--- a/scspell.py
+++ b/scspell.py
@@ -60,6 +60,19 @@ def main():
         action='store')
     dictgroup.add_argument('-i', '--gen-id', dest='gen_id', action='store_true',
                            help='generate a unique file-id string')
+    dictgroup.add_argument('--merge-fileids', nargs=2,
+                           metavar=('TOID', 'FROMID'),
+                           help="""merge these two fileids, keeping
+                           TOID and discarding FROMID.  Combine their
+                           wordlists in the dictionary, and the
+                           filenames associated with them in the
+                           fileid map.  TOID and FROMID may be given
+                           as fileids, or as filenames in which case
+                           the fileids corresponding to those files
+                           are operated on.  Does NOT look for or consider
+                           any fileids embedded in to-be-spellchecked files.
+                           If your filenames look like fileids, do it by
+                           hand.""")
 
     parser.add_argument('-D', '--debug', dest='debug', action='store_true',
                         help='print extra debugging information')
@@ -80,6 +93,9 @@ def main():
         scspell.export_dictionary(args.export_filename)
         print("Exported dictionary to '{}'".format(args.export_filename),
               file=sys.stderr)
+    elif args.merge_fileids is not None:
+        scspell.merge_fileids(args.merge_fileids[0], args.merge_fileids[1],
+                              args.override_filename, args.relative_to)
     elif len(args.files) < 1:
         parser.error('No files specified')
     else:

--- a/scspell.py
+++ b/scspell.py
@@ -65,7 +65,7 @@ def main():
         help='generate a unique file-id string')
     dictgroup.add_argument(
         '--merge-fileids', nargs=2,
-        metavar=('TOID', 'FROMID'),
+        metavar=('FROMID', 'TOID'),
         help="""merge these two fileids, keeping TOID and discarding FROMID.
         Combine their wordlists in the dictionary, and the filenames
         associated with them in the fileid map.  TOID and FROMID may

--- a/scspell.py
+++ b/scspell.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 
 import argparse
 import sys
-import uuid
 
 import scspell
 
@@ -103,7 +102,7 @@ def main():
         scspell.set_verbosity(scspell.VERBOSITY_MAX)
 
     if args.gen_id:
-        print('scspell-id: %s' % str(uuid.uuid1()))
+        print('scspell-id: %s' % scspell.get_new_fileid())
     elif args.dictionary is not None:
         scspell.set_dictionary(args.dictionary)
     elif args.export_filename is not None:

--- a/scspell.py
+++ b/scspell.py
@@ -39,6 +39,11 @@ def main():
     parser.add_argument('--report-only', dest='report', action='store_true',
                         help='non-interactive report of spelling errors')
     parser.add_argument(
+        '--relative-to', dest='relative_to',
+        help='Use file paths relative to here in fileid map.  '
+        'This is required to enable use of the fileid map',
+        action='store')
+    parser.add_argument(
         '--set-dictionary', dest='dictionary',
         help='permanently set location of dictionary to FILE', metavar='FILE',
         action='store')
@@ -75,6 +80,7 @@ def main():
     else:
         okay = scspell.spell_check(args.files,
                                    args.override_filename,
+                                   args.relative_to,
                                    args.report,
                                    args.c_escapes)
         return 0 if okay else 1

--- a/scspell.py
+++ b/scspell.py
@@ -55,7 +55,7 @@ def main():
                         help='print extra debugging information')
     parser.add_argument('--version', action='version',
                         version='%(prog)s ' + scspell.__version__)
-    parser.add_argument('files', nargs='+', help='files to check')
+    parser.add_argument('files', nargs='*', help='files to check')
 
     args = parser.parse_args()
 

--- a/scspell.py
+++ b/scspell.py
@@ -32,30 +32,35 @@ import scspell
 def main():
     parser = argparse.ArgumentParser(description=__doc__, prog='scspell')
 
-    parser.add_argument(
+    dictgroup = parser.add_argument_group("dictionary file management")
+    spellgroup = parser.add_argument_group("spellcheck control")
+
+    spellgroup.add_argument('--report-only', dest='report', action='store_true',
+                            help='non-interactive report of spelling errors')
+    spellgroup.add_argument('--no-c-escapes', dest='c_escapes',
+                            action='store_false', default=True,
+                            help="treat \\label as label, for e.g. LaTeX")
+
+    dictgroup.add_argument(
         '--override-dictionary', dest='override_filename',
         help='set location of dictionary to FILE, for current session only',
         metavar='FILE', action='store')
-    parser.add_argument('--report-only', dest='report', action='store_true',
-                        help='non-interactive report of spelling errors')
-    parser.add_argument(
+    dictgroup.add_argument(
+        '--set-dictionary', dest='dictionary',
+        help='permanently set location of dictionary to FILE', metavar='FILE',
+        action='store')
+    dictgroup.add_argument(
+        '--export-dictionary', dest='export_filename',
+        help='export current dictionary to FILE', metavar='FILE',
+        action='store')
+    dictgroup.add_argument(
         '--relative-to', dest='relative_to',
         help='Use file paths relative to here in fileid map.  '
         'This is required to enable use of the fileid map',
         action='store')
-    parser.add_argument(
-        '--set-dictionary', dest='dictionary',
-        help='permanently set location of dictionary to FILE', metavar='FILE',
-        action='store')
-    parser.add_argument(
-        '--export-dictionary', dest='export_filename',
-        help='export current dictionary to FILE', metavar='FILE',
-        action='store')
-    parser.add_argument('-i', '--gen-id', dest='gen_id', action='store_true',
-                        help='generate a unique file-id string')
-    parser.add_argument('--no-c-escapes', dest='c_escapes',
-                        action='store_false', default=True,
-                        help="treat \\label as label, for e.g. LaTeX")
+    dictgroup.add_argument('-i', '--gen-id', dest='gen_id', action='store_true',
+                           help='generate a unique file-id string')
+
     parser.add_argument('-D', '--debug', dest='debug', action='store_true',
                         help='print extra debugging information')
     parser.add_argument('--version', action='version',

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -661,6 +661,13 @@ def export_dictionary(filename):
     shutil.copyfile(locate_dictionary(), filename)
 
 
+def find_dict_file(override_dictionary):
+    verify_user_data_dir()
+    dict_file = locate_dictionary(
+    ) if override_dictionary is None else override_dictionary
+
+    return os.path.expandvars(os.path.expanduser(dict_file))
+
 def spell_check(source_filenames, override_dictionary=None,
                 relative_to=None, report_only=False, c_escapes=True):
     """Run the interactive spell checker on the set of source_filenames.
@@ -671,12 +678,8 @@ def spell_check(source_filenames, override_dictionary=None,
     :returns: None
 
     """
-    verify_user_data_dir()
+    dict_file = find_dict_file(override_dictionary)
 
-    dict_file = locate_dictionary(
-    ) if override_dictionary is None else override_dictionary
-
-    dict_file = os.path.expandvars(os.path.expanduser(dict_file))
     okay = True
     with CorporaFile(dict_file, relative_to) as dicts:
         ignores = set()
@@ -694,12 +697,15 @@ def merge_fileids(merge_to, merge_from,
     the fileid corresponding to it is the one merged.
 
     Use merge_to for the result, discarding merge_from."""
-    verify_user_data_dir()
-
-    dict_file = locate_dictionary(
-    ) if override_dictionary is None else override_dictionary
-
-    dict_file = os.path.expandvars(os.path.expanduser(dict_file))
+    dict_file = find_dict_file(override_dictionary)
 
     with CorporaFile(dict_file, relative_to) as dicts:
         dicts.merge_fileids(merge_to, merge_from)
+
+def rename_file(rename_from, rename_to,
+                override_dictionary=None, relative_to=None):
+    """Rename the file rename_from to rename_to, wrt. the fileid mappings."""
+    dict_file = find_dict_file(override_dictionary)
+
+    with CorporaFile(dict_file, relative_to) as dicts:
+        dicts.rename_file(rename_from, rename_to)

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -709,3 +709,11 @@ def rename_file(rename_from, rename_to,
 
     with CorporaFile(dict_file, relative_to) as dicts:
         dicts.rename_file(rename_from, rename_to)
+
+def delete_files(delete_files,
+                override_dictionary=None, relative_to=None):
+    """Remove all trace of delete_file."""
+    dict_file = find_dict_file(override_dictionary)
+    with CorporaFile(dict_file, relative_to) as dicts:
+        for file in delete_files:
+            dicts.delete_file(file)

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -684,3 +684,22 @@ def spell_check(source_filenames, override_dictionary=None,
             if not spell_check_file(f, dicts, ignores, report_only, c_escapes):
                 okay = False
     return okay
+
+def merge_fileids(merge_to, merge_from,
+                  override_dictionary=None, relative_to=None):
+    """Merge the fileids specified by merge_to and merge_from.
+
+    Combine the wordlists in the specified dictionary, and their fileid map
+    entries.  They each may be either a fileid, or a filename.  If a filename,
+    the fileid corresponding to it is the one merged.
+
+    Use merge_to for the result, discarding merge_from."""
+    verify_user_data_dir()
+
+    dict_file = locate_dictionary(
+    ) if override_dictionary is None else override_dictionary
+
+    dict_file = os.path.expandvars(os.path.expanduser(dict_file))
+
+    with CorporaFile(dict_file, relative_to) as dicts:
+        dicts.merge_fileids(merge_to, merge_from)

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -688,7 +688,7 @@ def spell_check(source_filenames, override_dictionary=None,
                 okay = False
     return okay
 
-def merge_fileids(merge_to, merge_from,
+def merge_fileids(merge_from, merge_to,
                   override_dictionary=None, relative_to=None):
     """Merge the fileids specified by merge_to and merge_from.
 
@@ -700,7 +700,7 @@ def merge_fileids(merge_to, merge_from,
     dict_file = find_dict_file(override_dictionary)
 
     with CorporaFile(dict_file, relative_to) as dicts:
-        dicts.merge_fileids(merge_to, merge_from)
+        dicts.merge_fileids(merge_from, merge_to)
 
 def rename_file(rename_from, rename_to,
                 override_dictionary=None, relative_to=None):

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -182,6 +182,10 @@ def make_unique(items):
         return False
     return [i for i in items if first_occurrence(i)]
 
+def get_new_fileid():
+    """Produce a new fileid string."""
+    return str(uuid.uuid1())
+
 
 def decompose_token(token):
     """Divide a token into a list of strings of letters.
@@ -347,8 +351,7 @@ def handle_add(unmatched_subtokens, filename, fq_filename, file_id_ref, dicts):
                 dicts.add_by_fileid(subtoken, file_id)
                 break
             elif offer_N and (ch == 'N'):
-                # TBD: uuid.uuid1() call should be shared with scspell.py
-                file_id = str(uuid.uuid1())
+                file_id = get_new_fileid()
                 file_id_ref[0] = file_id
                 print("New fileid {0} for {1}".format(file_id, filename),
                       file=sys.stderr)

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -244,9 +244,16 @@ class CorporaFile(object):
         mapping_file = self._filename + ".fileids.json"
         try:
             with io.open(mapping_file, mode='r', encoding='utf-8') as mf:
-                self._fileid_mapping = json.load(mf)
-                _util.mutter(_util.VERBOSITY_DEBUG,
-                             "got fileid mapping:\n{0}".format(self._fileid_mapping))
+                try:
+                    self._fileid_mapping = json.load(mf)
+                    _util.mutter(_util.VERBOSITY_DEBUG,
+                                 "got fileid mapping:\n{0}".format(self._fileid_mapping))
+                except ValueError as e:
+                    # Error during file creation might leave an empty file
+                    # here.  Not necessarily fatal, but report it.
+                    _util.mutter(_util.VERBOSITY_NORMAL,
+                                 "Couldn't load fileid mapping from {0}: {1}"
+                                 .format(mapping_file, e))
         except IOError as e:
             if e.errno == errno.ENOENT:
                 _util.mutter(_util.VERBOSITY_DEBUG,

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -258,7 +258,7 @@ class CorporaFile(object):
                         mapping_file, e.errno, e.strerror))
 
         # Build reverse map
-        for k,v in self._fileid_mapping.iteritems():
+        for k,v in self._fileid_mapping.items():
             for f in v:
                 self._revfileid_mapping[f] = k
 

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -411,7 +411,7 @@ class CorporaFile(object):
             return True
         return False
 
-    def merge_fileids(self, merge_to, merge_from):
+    def merge_fileids(self, merge_from, merge_to):
         if self.fileid_exists(merge_to):
             id_to = merge_to
         else:

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -591,7 +591,9 @@ class CorporaFile(object):
                     # http://stackoverflow.com/questions/36003023/json-dump-failing-with-must-be-unicode-not-str-typeerror
                     tstr = json.dumps(od, ensure_ascii=False, indent=2)
                     if isinstance(tstr, str):
-                        tstr = tstr.decode("utf-8")
+                        # Apply py2 workaround only on py2
+                        if sys.version_info[0] == 2:
+                            tstr = tstr.decode("utf-8")
                     mf.write(tstr)
                 self._fileid_mapping_is_dirty = False
             except IOError as e:

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -499,27 +499,29 @@ class CorporaFile(object):
         self._fileid_mapping_is_dirty = True
 
     def rename_file(self, rename_from, rename_to):
-        if rename_from not in self._revfileid_mapping:
+        (from_fq, from_rel) = self._fn_to_fq_rel(rename_from)
+        (to_fq, to_rel) = self._fn_to_fq_rel(rename_to)
+        if from_rel not in self._revfileid_mapping:
             _util.mutter(_util.VERBOSITY_NORMAL,
                          "No fileid for " + rename_from)
             return;
 
-        if rename_to in self._revfileid_mapping:
-            self.delete_file(rename_to)
+        if to_rel in self._revfileid_mapping:
+            self.delete_file(to_rel)
 
-        id_from = self._revfileid_mapping[rename_from]
+        id_from = self._revfileid_mapping[from_rel]
 
         _util.mutter(_util.VERBOSITY_NORMAL,
                      "Switching fileid {0} from {1} to {2}".format(
-                         id_from, rename_from, rename_to))
+                         id_from, from_rel, to_rel))
 
         fns = self._fileid_mapping[id_from]
-        fns.remove(rename_from)
-        fns.append(rename_to)
+        fns.remove(from_rel)
+        fns.append(to_rel)
         self._fileid_mapping[id_from] = sorted(fns)
 
-        self._revfileid_mapping[rename_to] = id_from
-        del self._revfileid_mapping[rename_from]
+        self._revfileid_mapping[to_rel] = id_from
+        del self._revfileid_mapping[from_rel]
         self._fileid_mapping_is_dirty = True
 
     def get_filetypes(self):

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -382,6 +382,14 @@ class CorporaFile(object):
                              "left!".format(fq_filename, self._relative_to))
         return rfn
 
+    def _fn_to_fq_rel(self, filename):
+        """Given a filename, returns the tuple
+           (fully-qualified filename, relative filename)
+           relative to the --relative-to path"""
+        fqfilename = os.path.normcase(os.path.realpath(filename))
+        relfilename = self._make_relative_filename(fqfilename)
+        return (fqfilename, relfilename)
+
     def new_file_and_fileid(self, fq_filename, file_id):
         """Add a mapping for this filename and file_id"""
 
@@ -424,8 +432,7 @@ class CorporaFile(object):
         else:
             fnto = merge_to
             if self._relative_to is not None:
-                toasfqfn = os.path.normcase(os.path.realpath(fnto))
-                fnto = self._make_relative_filename(toasfqfn)
+                (toasfqfn, fnto) = self._fn_to_fq_rel(fnto)
             id_to = self.fileid_of_rel_file(fnto)
             if id_to is None:
                 raise SystemExit("Can't find merge_to {0} as fileid or file".
@@ -436,8 +443,7 @@ class CorporaFile(object):
         else:
             fnfrom = merge_from
             if self._relative_to is not None:
-                fromasfqfn = os.path.normcase(os.path.realpath(fnfrom))
-                fnfrom = self._make_relative_filename(fromasfqfn)
+                (fromasfqfn, fnfrom) = self._fn_to_fq_rel(fnfrom)
             id_from = self.fileid_of_rel_file(fnfrom)
             if id_from is None:
                 raise SystemExit("Can't find merge_from {0} as fileid or file".
@@ -465,8 +471,7 @@ class CorporaFile(object):
         self._fileid_mapping_is_dirty = True
 
     def delete_file(self, filename):
-        fqfilename = os.path.normcase(os.path.realpath(filename))
-        relfilename = self._make_relative_filename(fqfilename)
+        (fqfilename, relfilename) = self._fn_to_fq_rel(filename)
         try:
             id = self._revfileid_mapping[relfilename]
         except:

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -457,6 +457,43 @@ class CorporaFile(object):
         self._fileid_mapping[id_to] = sorted(tofiles)
         self._fileid_mapping_is_dirty = True
 
+    def delete_file(self, filename):
+        try:
+            id = self._revfileid_mapping[filename]
+        except:
+            return
+        _util.mutter(_util.VERBOSITY_NORMAL,
+                     "Removing {0} <-> {1} mappings".format(
+                         filename, id))
+        del self._revfileid_mapping[filename]
+        fns = self._fileid_mapping[id]
+        fns.remove(filename)
+        if len(fns) == 0:
+            del self._fileid_mapping[id]
+        self._fileid_mapping_is_dirty = True
+
+    def rename_file(self, rename_from, rename_to):
+        if rename_from not in self._revfileid_mapping:
+            _util.mutter(_util.VERBOSITY_NORMAL,
+                         "No fileid for " + rename_from)
+            return;
+        self.delete_file(rename_to)
+
+        id_from = self._revfileid_mapping[rename_from]
+
+        _util.mutter(_util.VERBOSITY_NORMAL,
+                     "Switching fileid {0} from {1} to {2}".format(
+                         id_from, rename_from, rename_to))
+
+        fns = self._fileid_mapping[id_from]
+        fns.remove(rename_from)
+        fns.append(rename_to)
+        self._fileid_mapping[id_from] = sorted(fns)
+
+        self._revfileid_mapping[rename_to] = id_from
+        del self._revfileid_mapping[rename_from]
+        self._fileid_mapping_is_dirty = True
+
     def get_filetypes(self):
         """Get a list of file types with type-specific corpora."""
         return [corpus.get_name() for corpus in self._filetype_dicts]


### PR DESCRIPTION
The description and some design notes are in the "Introduce fileid mapping file" commit header.
