### PR TITLE
Add "base dicts"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,32 @@ by using the ``--override-dictionary`` option::
 
     $ scspell --override-dictionary=/path/to/dictionary_file.txt source_file1 ...
 
+--base-dict BASE_DICT\
+   A *base dictionary* is consulted for its words, but is not modified
+   at runtime.  By using
+
+    $ scspell --base-dict ~/.dict --override-dictionary proj/.dict source...
+
+   words added at runtime will be added to ``proj/.dict``, and
+   ``~/.dict`` will be left alone.  This way ``proj/.dict`` may be
+   limited only to the words added for ``proj/``.  This may be more
+   convenient when ``proj/.dict`` is committed to source control and
+   shared by many users.
+
+--use-builtin-base-dict\
+   Use the dictionary file shipped with scspell as a base dictionary.
+
+--filter-out-base-dicts\
+   Read the dictionary specified by the normal dictionary selection
+   options, called the ``project dict`` here.  Read the base
+   dictionaries specified by the base-dict options.  Remove from the
+   project dict all the words from the base dicts, and write the
+   project dict back out.
+
+   This may be useful when a project dict has been generated with an
+   older version of **scspell** that did not support base dicts.
+
+
 Installation
 ------------
 

--- a/scspell.py
+++ b/scspell.py
@@ -64,6 +64,10 @@ def main():
         help="Use scspell's default wordlist as a base dictionary ({0})"
         .format(scspell.SCSPELL_BUILTIN_DICT))
     dict_group.add_argument(
+        '--filter-out-base-dicts', action='store_true',
+        help='Remove from the dictionary file '
+             'all the words from the basedicts')
+    dict_group.add_argument(
         '--relative-to', dest='relative_to',
         help='use file paths relative to here in file ID map; '
              'this is required to enable use of the fileid map',
@@ -131,6 +135,8 @@ def main():
         scspell.delete_files(args.files,
                              args.override_filename,
                              args.base_dicts, args.relative_to)
+    elif args.filter_out_base_dicts:
+        scspell.filter_out_base_dicts(args.override_filename, args.base_dicts)
     elif len(args.files) < 1:
         parser.error('No files specified')
     else:

--- a/scspell.py
+++ b/scspell.py
@@ -55,6 +55,15 @@ def main():
         help='export current dictionary to FILE', metavar='FILE',
         action='store')
     dict_group.add_argument(
+        '--base-dict', dest='base_dicts', action='append', default=[],
+        metavar='BASE_DICT',
+        help="Match words from BASE_DICT, but don't modify it.")
+    dict_group.add_argument(
+        '--use-builtin-base-dict', dest='base_dicts',
+        action='append_const', const=scspell.SCSPELL_BUILTIN_DICT,
+        help="Use scspell's default wordlist as a base dictionary ({0})"
+        .format(scspell.SCSPELL_BUILTIN_DICT))
+    dict_group.add_argument(
         '--relative-to', dest='relative_to',
         help='use file paths relative to here in file ID map; '
              'this is required to enable use of the fileid map',
@@ -105,25 +114,29 @@ def main():
     elif args.dictionary is not None:
         scspell.set_dictionary(args.dictionary)
     elif args.export_filename is not None:
-        scspell.export_dictionary(args.export_filename)
+        scspell.export_dictionary(args.export_filename, args.base_dicts)
         print("Exported dictionary to '{}'".format(args.export_filename),
               file=sys.stderr)
     elif args.merge_file_ids is not None:
         scspell.merge_file_ids(args.merge_file_ids[0], args.merge_file_ids[1],
-                               args.override_filename, args.relative_to)
+                               args.override_filename,
+                               args.base_dicts, args.relative_to)
     elif args.rename_file is not None:
         scspell.rename_file(args.rename_file[0], args.rename_file[1],
-                            args.override_filename, args.relative_to)
+                            args.override_filename,
+                            args.base_dicts, args.relative_to)
     elif args.delete_files:
         if len(args.files) < 1:
             parser.error('No files specified for delete')
         scspell.delete_files(args.files,
-                             args.override_filename, args.relative_to)
+                             args.override_filename,
+                             args.base_dicts, args.relative_to)
     elif len(args.files) < 1:
         parser.error('No files specified')
     else:
         okay = scspell.spell_check(args.files,
                                    args.override_filename,
+                                   args.base_dicts,
                                    args.relative_to,
                                    args.report,
                                    args.c_escapes)

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -696,6 +696,18 @@ def spell_check(source_filenames, override_dictionary=None,
     return okay
 
 
+def filter_out_base_dicts(override_dictionary=None, base_dicts=[]):
+    """Remove from our dictionary the words from the base dicts.
+
+    This can be useful for migrating from a version of scspell that
+    did not support the --base-dicts option.
+
+    """
+    dict_file = find_dict_file(override_dictionary)
+    with CorporaFile(dict_file, base_dicts, None) as dicts:
+        dicts.filter_out_base_dicts()
+
+
 def merge_file_ids(merge_from, merge_to,
                    override_dictionary=None, base_dicts=[], relative_to=None):
     """Merge the fileids specified by merge_to and merge_from.

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -360,7 +360,7 @@ class CorporaFile(object):
                 newtokens.append(t)
         self._natural_dict._tokens = newtokens
 
-        for ext in self._extensions.keys():
+        for ext in self._extensions:
             # Generate a fake file name to use to query the base dicts.
             # Since we aren't using MATCH_FILEID, the basename won't be
             # used, only the extension.

--- a/scspell/_util.py
+++ b/scspell/_util.py
@@ -61,15 +61,11 @@ def open_with_encoding(filename, encoding=None, mode='r'):
 def detect_encoding(filename):
     """Return file encoding."""
 
-    # Thanks again stackoverflow for python 2 v 3,
-    # http://stackoverflow.com/questions/15032108/pythons-open-throws-different-errors-for-file-not-found-how-to-handle-b
-    fnotfound = getattr(__builtins__, 'FileNotFoundError', IOError)
-
-    # If the file doesn't exist, return the same thing detect_encoding gives
-    # us for an empty file, utf-8.
     try:
         input_file = open(filename, 'rb')
-    except fnotfound:
+    except (IOError, OSError):
+        # If the file doesn't exist, return the same thing
+        # detect_encoding gives us for an empty file, utf-8.
         return 'utf-8'
 
     try:

--- a/scspell/_util.py
+++ b/scspell/_util.py
@@ -60,8 +60,20 @@ def open_with_encoding(filename, encoding=None, mode='r'):
 
 def detect_encoding(filename):
     """Return file encoding."""
+
+    # Thanks again stackoverflow for python 2 v 3,
+    # http://stackoverflow.com/questions/15032108/pythons-open-throws-different-errors-for-file-not-found-how-to-handle-b
+    fnotfound = getattr(__builtins__, 'FileNotFoundError', IOError)
+
+    # If the file doesn't exist, return the same thing detect_encoding gives
+    # us for an empty file, utf-8.
     try:
-        with open(filename, 'rb') as input_file:
+        input_file = open(filename, 'rb')
+    except fnotfound:
+        return 'utf-8'
+
+    try:
+        with input_file:
             from lib2to3.pgen2 import tokenize as lib2to3_tokenize
             encoding = lib2to3_tokenize.detect_encoding(input_file.readline)[0]
 

--- a/test.cram
+++ b/test.cram
@@ -47,3 +47,40 @@ Test file ID manipulations
     $ diff tests/fileidmap/dictionary tests/fileidmap/dictionary.post
     $ diff tests/fileidmap/dictionary.fileids.json \
     >      tests/fileidmap/dictionary.fileids.json.post
+
+Base dicts tests
+
+    $ T=tests/basedicts
+
+With all the dictionaries, clean run:
+
+    $ $SCSPELL --override-dictionary $T/dictionary \
+    >     --use-builtin-base-dict \
+    >     --base-dict $T/base-dictionary-1 --base-dict $T/base-dictionary-2 \
+    >     $T/testfile
+
+Leave out everything but the override dictionary
+
+    $ $SCSPELL --override-dictionary $T/dictionary $T/testfile
+    tests/basedicts/testfile:1: 'hoth' not found in dictionary (from token 'hoth')
+    tests/basedicts/testfile:1: 'apple' not found in dictionary (from token 'apple')
+    tests/basedicts/testfile:1: 'bakingsoda' not found in dictionary (from token 'bakingsoda')
+    tests/basedicts/testfile:2: 'perfectly' not found in dictionary (from token 'perfectly')
+    tests/basedicts/testfile:3: 'also' not found in dictionary (from token 'also')
+    tests/basedicts/testfile:3: 'yavin' not found in dictionary (from token 'yavin')
+    [1]
+
+Add in just the first base dict
+
+    $ $SCSPELL --override-dictionary $T/dictionary \
+    >     --base-dict $T/base-dictionary-1 $T/testfile
+    tests/basedicts/testfile:1: 'apple' not found in dictionary (from token 'apple')
+    tests/basedicts/testfile:1: 'bakingsoda' not found in dictionary (from token 'bakingsoda')
+    tests/basedicts/testfile:2: 'perfectly' not found in dictionary (from token 'perfectly')
+    tests/basedicts/testfile:3: 'also' not found in dictionary (from token 'also')
+    [1]
+
+Filter out builtin-base-dict from base-dictionary-2
+    $ $SCSPELL --override-dictionary $T/base-dictionary-2 \
+    >     --use-builtin-base-dict --filter-out-base-dicts
+    $ diff -u $T/base-dictionary-2 $T/base-dictionary-2.filtered

--- a/tests/basedicts/base-dictionary-1
+++ b/tests/basedicts/base-dictionary-1
@@ -1,0 +1,3 @@
+NATURAL:
+hoth
+yavin

--- a/tests/basedicts/base-dictionary-2
+++ b/tests/basedicts/base-dictionary-2
@@ -1,0 +1,4 @@
+NATURAL:
+ammonia
+bakingsoda
+lye

--- a/tests/basedicts/base-dictionary-2.filtered
+++ b/tests/basedicts/base-dictionary-2.filtered
@@ -1,0 +1,3 @@
+NATURAL:
+bakingsoda
+

--- a/tests/basedicts/dictionary
+++ b/tests/basedicts/dictionary
@@ -1,0 +1,3 @@
+NATURAL:
+cromulent
+embiggen

--- a/tests/basedicts/testfile
+++ b/tests/basedicts/testfile
@@ -1,0 +1,3 @@
+hoth apple bakingsoda
+perfectly cromulent
+also embiggen yavin


### PR DESCRIPTION
One or more --base-dict's may be specified on the command line.  We
search for tokens in these dicts, but do not add words to them.

--use-builtin-base-dict uses the dictionary.txt in SCSPELL_DATA_DIR as
a base dict.

This allows a project-specific dictionary to be maintained containing
only words from the project, without including the full 844K base
dictionary and its license terms.  E.g.

$ cd PROJECT
$ scspell --override-dictionary .scspell/dictionary.txt \
          --use-builtin-base-dict \
          $PROJECT_FILES

Another benefit is that as scspell's dictionary is updated over time,
scspell invoked with --use-builtin-base-dict will reflect the updated
dictionary automatically.
