### PR TITLE
Make "make check" scspell use a proj dict

### DIFF
--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -1,0 +1,32 @@
+FILETYPE: Python; .py
+argparse
+nargs
+
+FILEID: e497803c-523a-11de-ae42-0017f2ee0f37
+amma
+atural
+elta
+eplace
+gnore
+lpha
+mispeld
+nworld
+ontext
+rogramming
+varaible
+
+NATURAL:
+american
+english
+github
+https
+myint
+pelzl
+printf
+scspell
+sourceforge
+stderr
+sudo
+travis
+wordlist
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,5 @@ exclude test.cram
 exclude tox.ini
 exclude tests
 recursive-exclude tests *
+exclude .scspell
+recursive-exclude .scspell *

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,6 @@ check:
 	pycodestyle scspell.py scspell setup.py
 	check-manifest
 	rstcheck README.rst
-	scspell scspell.py setup.py
+	./scspell.py --use-builtin-base-dict \
+	    --override-dictionary .scspell/dictionary.txt \
+	    scspell.py setup.py README.rst

--- a/README.rst
+++ b/README.rst
@@ -98,15 +98,15 @@ prompted with the following options for every subtoken:
     add to (f)ile-specific dictionary
         Add this subtoken to the dictionary associated with the
         current file. You will see this option only for files which
-        have such an embedded ID or which have an entry in the fileid
+        have such an embedded ID or which have an entry in the file ID
         mapping.  See `Creating File IDs`_ for details.
 
     add to (N)ew file-specific dictionary
         Create a new file ID for the current file, record the new
-        file ID in the fileid mapping, and add this subtoken to a new
+        file ID in the file ID mapping, and add this subtoken to a new
         file-specific dictionary associated with that file ID.  You will
         see this option only for files which have neither an embedded ID nor
-        an entry in the fileid mapping, and only if the ``--relative-to``
+        an entry in the file ID mapping, and only if the ``--relative-to``
 	option is given.  See `Creating File IDs`_ for details.
 
     add to (n)atural language dictionary
@@ -156,7 +156,7 @@ find the file ID:
 
       scspell-id: <unique ID>
 
-2. An entry in the fileid mapping file ties a filename to a file ID.
+2. An entry in the file ID mapping file ties a filename to a file ID.
 
 The unique ID must consist only of letters, numbers, underscores, and dashes.
 **scspell** can generate suitable unique ID strings using the ``--gen-id`` option::
@@ -168,13 +168,13 @@ The unique ID must consist only of letters, numbers, underscores, and dashes.
 
 During interactive use, the ``(a)dd to dictionary`` -> ``add to (N)ew
 file-specific dictionary`` option will create a new File ID for the
-current file, and add it to the fileid mapping file.
+current file, and add it to the file ID mapping file.
 
 
 --relative-to RELATIVE_TO\ 
- The filenames stored in the fileid mapping are relative paths.  This
+ The filenames stored in the file ID mapping are relative paths.  This
  option specifies what they're relative to.  If this option is not
- specified, the fileid mapping will not be consulted, and the ``add to (N)ew
+ specified, the file ID mapping will not be consulted, and the ``add to (N)ew
  file-specific dictionary`` option will not be offered.
 
 
@@ -182,13 +182,13 @@ current file, and add it to the fileid mapping file.
 Managing File IDs
 -----------------
 
-These options direct **scspell** to manipulate the fileid mapping.
-(These can all be accomplished by editing the fileid mapping
-manually).  These have no effect on File IDs embedded in files.
+These options direct **scspell** to manipulate the file ID mapping.
+(These can all be accomplished by editing the file ID mapping
+manually).  These have no effect on file IDs embedded in files.
 
 --rename-file FROM_FILE TO_FILE
    Changes the filename that a File ID maps to.  After renaming a file
-   that has a file-specific dictionary and an entry in the fileid
+   that has a file-specific dictionary and an entry in the file ID
    mapping, you can use this option to have the entry "follow" the file.
 
 --delete-files\ 

--- a/scspell.py
+++ b/scspell.py
@@ -114,7 +114,7 @@ def main():
         scspell.set_verbosity(scspell.VERBOSITY_MAX)
 
     if args.gen_id:
-        print('scspell-id: %s' % scspell.get_new_fileid())
+        print('scspell-id: %s' % scspell.get_new_file_id())
     elif args.dictionary is not None:
         scspell.set_dictionary(args.dictionary)
     elif args.export_filename is not None:

--- a/scspell.py
+++ b/scspell.py
@@ -66,11 +66,11 @@ def main():
     dict_group.add_argument(
         '--filter-out-base-dicts', action='store_true',
         help='Remove from the dictionary file '
-             'all the words from the basedicts')
+             'all the words from the base dicts')
     dict_group.add_argument(
         '--relative-to', dest='relative_to',
-        help='use file paths relative to here in file ID map; '
-             'this is required to enable use of the fileid map',
+        help='use file paths relative to here in file ID map.  '
+             'This is required to enable use of the file ID map',
         action='store')
     dict_group.add_argument(
         '-i', '--gen-id', dest='gen_id', action='store_true',
@@ -80,22 +80,22 @@ def main():
         metavar=('FROM_ID', 'TO_ID'),
         help='merge these two file IDs, keeping TO_ID and discarding FROM_ID; '
              'combine their word lists in the dictionary, and the filenames '
-             'associated with them in the fileid map; TO_ID and FROM_ID may '
-             'be given as fileids, or as filenames in which case the fileids '
-             'corresponding to those files are operated on; does NOT look '
-             'for or consider any fileids embedded in to-be-spell-checked '
-             'files; if your filenames look like fileids, do it by hand')
+             'associated with them in the file ID map; TO_ID and FROM_ID may '
+             'be given as file IDs, or as filenames in which case the file '
+             'IDs corresponding to those files are operated on; does NOT look '
+             'for or consider any file IDs embedded in to-be-spell-checked '
+             'files; if your filenames look like file IDs, do it by hand')
     dict_group.add_argument(
         '--rename-file', nargs=2,
         metavar=('FROM_FILE', 'TO_FILE'),
         help='inform scspell that FROM_FILE has been renamed TO_FILE; '
-             'if an entry in the fileid mapping references FROM_FILE, it will '
-             'be modified to reference TO_FILE instead')
+             'if an entry in the file ID mapping references FROM_FILE, it '
+             'will be modified to reference TO_FILE instead')
     dict_group.add_argument(
         '--delete-files', action='store_true', default=False,
         help='inform scspell that the listed files have been deleted; all '
-             'fileid mappings for the files will be removed; if all uses of '
-             'that fileid have been removed, the corresponding file-private '
+             'file ID mappings for the files will be removed; if all uses of '
+             'that file ID have been removed, the corresponding file-private '
              'dictionary will be removed; this will not spell check the '
              'files')
 

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -182,7 +182,7 @@ def make_unique(items):
     return [i for i in items if first_occurrence(i)]
 
 
-def get_new_fileid():
+def get_new_file_id():
     """Produce a new fileid string."""
     return str(uuid.uuid1())
 
@@ -352,7 +352,7 @@ def handle_add(unmatched_subtokens, filename, fq_filename, file_id_ref, dicts):
                 dicts.add_by_fileid(subtoken, file_id)
                 break
             elif offer_N and (ch == 'N'):
-                file_id = get_new_fileid()
+                file_id = get_new_file_id()
                 file_id_ref[0] = file_id
                 print("New fileid {0} for {1}".format(file_id, filename),
                       file=sys.stderr)


### PR DESCRIPTION
This way "make check" doesn't depend on any state outside the repo (e.g. ~/.scspell/dictionary.txt).

This includes changing "fileid" to "file ID" in README.rst and scspell.py.

I had to invoke scspell from the makefile as ./scspell.py because the scspell installed by "pip install scspell3k" doesn't have the base-dicts functionality.  And maybe running ./scspell.py is better anyway, as an extra check.

Getting scspell/*.py in shape to have make check run scspell on them as well will be a somewhat more involved effort.

Should make check run test.cram too?
