### PR TITLE
Change "make check" to spell-check all of scpell/*.py

### DIFF
--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-fromcorpus
 fromfiles
 newtokens
 relfilename
@@ -36,7 +35,6 @@ relfn
 reptstring
 revfileid
 sortedfilenames
-tocorpus
 tofiles
 tstr
 typeerror

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-fromasfqfn
 fromcorpus
 fromfiles
 newtokens
@@ -37,7 +36,6 @@ relfn
 reptstring
 revfileid
 sortedfilenames
-toasfqfn
 tocorpus
 tofiles
 tstr

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-fakefn
 fnfrom
 fnto
 fqfilename

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-copiedids
 fakefn
 fnfrom
 fnto

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,14 +28,12 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-fromfiles
 newtokens
 relfilename
 relfn
 reptstring
 revfileid
 sortedfilenames
-tofiles
 tstr
 typeerror
 

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,8 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-relfilename
-relfn
 reptstring
 revfileid
 sortedfilenames

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,8 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-fnfrom
-fnto
 fqfilename
 fromasfqfn
 fromcorpus

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-fqfilename
 fromasfqfn
 fromcorpus
 fromfiles

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-revfileid
 sortedfilenames
 tstr
 typeerror

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-reptstring
 revfileid
 sortedfilenames
 tstr

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -1,6 +1,9 @@
 FILETYPE: Python; .py
 argparse
+configparser
 nargs
+pgen
+strerror
 
 FILEID: e497803c-523a-11de-ae42-0017f2ee0f37
 amma
@@ -15,9 +18,45 @@ ontext
 rogramming
 varaible
 
+FILEID: a5ba480a-46bf-11e6-907f-843835579daa
+atural
+eplace
+gnore
+matchobj
+ntext
+ontext
+rogramming
+
+FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
+copiedids
+fakefn
+fnfrom
+fnto
+fqfilename
+fromasfqfn
+fromcorpus
+fromfiles
+newtokens
+relfilename
+relfn
+reptstring
+revfileid
+sortedfilenames
+toasfqfn
+tocorpus
+tofiles
+tstr
+typeerror
+
+FILEID: 8bfe4130-46c1-11e6-907f-843835579daa
+appdata
+progname
+
 NATURAL:
 american
 english
+fileid
+fileids
 github
 https
 myint
@@ -25,8 +64,12 @@ pelzl
 printf
 scspell
 sourceforge
+stackoverflow
 stderr
 sudo
+tokenize
 travis
 wordlist
+wordlists
+workaround
 

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-tstr
 typeerror
 
 FILEID: 8bfe4130-46c1-11e6-907f-843835579daa

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-sortedfilenames
 tstr
 typeerror
 

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -28,7 +28,6 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
-newtokens
 relfilename
 relfn
 reptstring

--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -22,7 +22,6 @@ FILEID: a5ba480a-46bf-11e6-907f-843835579daa
 atural
 eplace
 gnore
-matchobj
 ntext
 ontext
 rogramming

--- a/.scspell/dictionary.txt.fileids.json
+++ b/.scspell/dictionary.txt.fileids.json
@@ -1,0 +1,11 @@
+{
+  "a5ba480a-46bf-11e6-907f-843835579daa": [
+    "scspell/__init__.py"
+  ],
+  "3dadcb18-46c1-11e6-907f-843835579daa": [
+    "scspell/_corpus.py"
+  ],
+  "8bfe4130-46c1-11e6-907f-843835579daa": [
+    "scspell/_portable.py"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ check:
 	pycodestyle scspell.py scspell setup.py
 	check-manifest
 	rstcheck README.rst
-	./scspell.py --use-builtin-base-dict \
+	./scspell.py --use-builtin-base-dict --relative-to . \
 	    --override-dictionary .scspell/dictionary.txt \
-	    scspell.py setup.py README.rst
+	    scspell.py setup.py README.rst scspell/*.py

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -183,7 +183,7 @@ def make_unique(items):
 
 
 def get_new_file_id():
-    """Produce a new fileid string."""
+    """Produce a new file ID string."""
     return str(uuid.uuid1())
 
 
@@ -354,7 +354,7 @@ def handle_add(unmatched_subtokens, filename, fq_filename, file_id_ref, dicts):
             elif offer_N and (ch == 'N'):
                 file_id = get_new_file_id()
                 file_id_ref[0] = file_id
-                print("New fileid {0} for {1}".format(file_id, filename),
+                print("New file ID {0} for {1}".format(file_id, filename),
                       file=sys.stderr)
                 dicts.new_file_and_fileid(fq_filename, file_id)
                 dicts.add_by_fileid(subtoken, file_id)
@@ -710,11 +710,11 @@ def filter_out_base_dicts(override_dictionary=None, base_dicts=[]):
 
 def merge_file_ids(merge_from, merge_to,
                    override_dictionary=None, base_dicts=[], relative_to=None):
-    """Merge the fileids specified by merge_to and merge_from.
+    """Merge the file IDs specified by merge_to and merge_from.
 
-    Combine the wordlists in the specified dictionary, and their fileid map
-    entries.  They each may be either a fileid, or a filename.  If a filename,
-    the fileid corresponding to it is the one merged.
+    Combine the wordlists in the specified dictionary, and their file ID map
+    entries.  They each may be either a file ID, or a filename.  If a filename,
+    the file ID corresponding to it is the one merged.
 
     Use merge_to for the result, discarding merge_from."""
     dict_file = find_dict_file(override_dictionary)
@@ -725,7 +725,7 @@ def merge_file_ids(merge_from, merge_to,
 
 def rename_file(rename_from, rename_to,
                 override_dictionary=None, base_dicts=[], relative_to=None):
-    """Rename the file rename_from to rename_to, wrt. the fileid mappings."""
+    """Rename the file rename_from to rename_to, wrt. the file ID mappings."""
     dict_file = find_dict_file(override_dictionary)
 
     with CorporaFile(dict_file, base_dicts, relative_to) as dicts:

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -105,10 +105,10 @@ class MatchDescriptor(object):
     """A MatchDescriptor captures the information necessary to represent a
     token matched within some source code."""
 
-    def __init__(self, text, matchobj):
+    def __init__(self, text, match_obj):
         self._data = text
-        self._pos = matchobj.start()
-        self._token = matchobj.group()
+        self._pos = match_obj.start()
+        self._token = match_obj.group()
         self._context = None
         self._line_num = None
 

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -520,12 +520,12 @@ class CorporaFile(object):
         self._fileid_dicts.remove(from_corpus)
 
         # Add id_from's files to id_to
-        fromfiles = self._fileid_mapping[id_from]
-        tofiles = self._fileid_mapping[id_to]
-        for f in fromfiles:
-            tofiles.append(f)
+        from_files = self._fileid_mapping[id_from]
+        to_files = self._fileid_mapping[id_to]
+        for f in from_files:
+            to_files.append(f)
             self._revfileid_mapping[f] = id_to
-        self._fileid_mapping[id_to] = sorted(tofiles)
+        self._fileid_mapping[id_to] = sorted(to_files)
         self._fileid_mapping_is_dirty = True
 
     def delete_file(self, filename):

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -652,8 +652,8 @@ class CorporaFile(object):
             # into git.
             od = OrderedDict()
             copied_ids = set({})
-            sortedfilenames = sorted(self._reverse_file_id_mapping)
-            for fn in sortedfilenames:
+            sorted_filenames = sorted(self._reverse_file_id_mapping)
+            for fn in sorted_filenames:
                 id = self._reverse_file_id_mapping[fn]
                 if id in copied_ids:
                     continue

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -445,8 +445,8 @@ class CorporaFile(object):
         """Given a filename relative to ".", return the filename
            relative to the --relative-to path"""
         fq_filename = os.path.normcase(os.path.realpath(filename))
-        relfilename = self._make_relative_filename(fq_filename)
-        return relfilename
+        rel_filename = self._make_relative_filename(fq_filename)
+        return rel_filename
 
     def new_file_and_fileid(self, fq_filename, file_id):
         """Add a mapping for this filename and file_id"""
@@ -454,15 +454,15 @@ class CorporaFile(object):
         if self._relative_to is None:
             raise AssertionError("new_file_and_fileid called without "
                                  "--relative-to")
-        relfn = self._make_relative_filename(fq_filename)
-        if relfn in self._revfileid_mapping:
+        rel_filename = self._make_relative_filename(fq_filename)
+        if rel_filename in self._revfileid_mapping:
             raise AssertionError("{0} already has file_id {1}".format(
-                relfn, self._revfileid_mapping[relfn]))
-        self._revfileid_mapping[relfn] = file_id
+                rel_filename, self._revfileid_mapping[rel_filename]))
+        self._revfileid_mapping[rel_filename] = file_id
         if file_id not in self._fileid_mapping:
             self._fileid_mapping[file_id] = []
-        if relfn not in self._fileid_mapping[file_id]:
-            self._fileid_mapping[file_id].append(relfn)
+        if rel_filename not in self._fileid_mapping[file_id]:
+            self._fileid_mapping[file_id].append(rel_filename)
             self._fileid_mapping[file_id] = sorted(
                 self._fileid_mapping[file_id])
             self._fileid_mapping_is_dirty = True
@@ -476,8 +476,8 @@ class CorporaFile(object):
     def fileid_of_file(self, fq_filename):
         if self._relative_to is None:
             return None
-        relfn = self._make_relative_filename(fq_filename)
-        return self.fileid_of_rel_file(relfn)
+        rel_filename = self._make_relative_filename(fq_filename)
+        return self.fileid_of_rel_file(rel_filename)
 
     def fileid_exists(self, file_id):
         if file_id in self._fileid_mapping:
@@ -529,23 +529,23 @@ class CorporaFile(object):
         self._fileid_mapping_is_dirty = True
 
     def delete_file(self, filename):
-        relfilename = self._fn_to_rel(filename)
+        rel_filename = self._fn_to_rel(filename)
         try:
-            id = self._revfileid_mapping[relfilename]
+            id = self._revfileid_mapping[rel_filename]
         except:
-            if filename == relfilename:
+            if filename == rel_filename:
                 reptstring = filename
             else:
-                reptstring = "{0} ({1})".format(filename, relfilename)
+                reptstring = "{0} ({1})".format(filename, rel_filename)
             _util.mutter(_util.VERBOSITY_NORMAL,
                          "No file ID for {0}".format(reptstring))
             return
         _util.mutter(_util.VERBOSITY_NORMAL,
                      "Removing {0} <-> {1} mappings".format(
                          filename, id))
-        del self._revfileid_mapping[relfilename]
+        del self._revfileid_mapping[rel_filename]
         fns = self._fileid_mapping[id]
-        fns.remove(relfilename)
+        fns.remove(rel_filename)
         if len(fns) == 0:
             # No remaining files use this file ID.  Remove all trace of it.
             del self._fileid_mapping[id]

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -512,12 +512,12 @@ class CorporaFile(object):
                          id_from=id_from, id_to=id_to))
 
         # merge wordlists
-        fromcorpus = self._fileids[id_from]
-        tocorpus = self._fileids[id_to]
-        for t in fromcorpus._tokens:
-            tocorpus.add(t)
+        from_corpus = self._fileids[id_from]
+        to_corpus = self._fileids[id_to]
+        for t in from_corpus._tokens:
+            to_corpus.add(t)
         del self._fileids[id_from]
-        self._fileid_dicts.remove(fromcorpus)
+        self._fileid_dicts.remove(from_corpus)
 
         # Add id_from's files to id_to
         fromfiles = self._fileid_mapping[id_from]

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -445,9 +445,9 @@ class CorporaFile(object):
         """Given a filename, returns the tuple
            (fully-qualified filename, relative filename)
            relative to the --relative-to path"""
-        fqfilename = os.path.normcase(os.path.realpath(filename))
-        relfilename = self._make_relative_filename(fqfilename)
-        return (fqfilename, relfilename)
+        fq_filename = os.path.normcase(os.path.realpath(filename))
+        relfilename = self._make_relative_filename(fq_filename)
+        return (fq_filename, relfilename)
 
     def new_file_and_fileid(self, fq_filename, file_id):
         """Add a mapping for this filename and file_id"""
@@ -530,7 +530,7 @@ class CorporaFile(object):
         self._fileid_mapping_is_dirty = True
 
     def delete_file(self, filename):
-        (fqfilename, relfilename) = self._fn_to_fq_rel(filename)
+        (fq_filename, relfilename) = self._fn_to_fq_rel(filename)
         try:
             id = self._revfileid_mapping[relfilename]
         except:

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -664,13 +664,13 @@ class CorporaFile(object):
             try:
                 with io.open(mapping_file, mode='w', encoding='utf-8') as mf:
                     # http://stackoverflow.com/questions/36003023/json-dump-failing-with-must-be-unicode-not-str-typeerror
-                    tstr = json.dumps(od, ensure_ascii=False,
-                                      indent=2, separators=(',', ': '))
-                    if isinstance(tstr, str):
+                    json_str = json.dumps(od, ensure_ascii=False,
+                                          indent=2, separators=(',', ': '))
+                    if isinstance(json_str, str):
                         # Apply py2 workaround only on py2
                         if sys.version_info[0] == 2:
-                            tstr = tstr.decode("utf-8")
-                    mf.write(tstr)
+                            json_str = json_str.decode("utf-8")
+                    mf.write(json_str)
                 self._fileid_mapping_is_dirty = False
             except IOError as e:
                 print("Warning: unable to write file ID mapping file '{0}' "

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -489,10 +489,10 @@ class CorporaFile(object):
         if self.fileid_exists(merge_to):
             id_to = merge_to
         else:
-            fnto = merge_to
+            filename_to = merge_to
             if self._relative_to is not None:
-                (toasfqfn, fnto) = self._fn_to_fq_rel(fnto)
-            id_to = self.fileid_of_rel_file(fnto)
+                (toasfqfn, filename_to) = self._fn_to_fq_rel(filename_to)
+            id_to = self.fileid_of_rel_file(filename_to)
             if id_to is None:
                 raise SystemExit("Can't find merge_to {0} as file ID or file".
                                  format(merge_to))
@@ -500,10 +500,10 @@ class CorporaFile(object):
         if self.fileid_exists(merge_from):
             id_from = merge_from
         else:
-            fnfrom = merge_from
+            filename_from = merge_from
             if self._relative_to is not None:
-                (fromasfqfn, fnfrom) = self._fn_to_fq_rel(fnfrom)
-            id_from = self.fileid_of_rel_file(fnfrom)
+                (fromasfqfn, filename_from) = self._fn_to_fq_rel(filename_from)
+            id_from = self.fileid_of_rel_file(filename_from)
             if id_from is None:
                 raise SystemExit("Can't find merge_from {0} as file ID or file"
                                  "".format(id_from))

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -652,13 +652,13 @@ class CorporaFile(object):
             # more stable, so it will result in less churn if it's checked
             # into git.
             od = OrderedDict()
-            copiedids = set({})
+            copied_ids = set({})
             sortedfilenames = sorted(self._revfileid_mapping)
             for fn in sortedfilenames:
                 id = self._revfileid_mapping[fn]
-                if id in copiedids:
+                if id in copied_ids:
                     continue
-                copiedids.add(id)
+                copied_ids.add(id)
                 od[id] = sorted(self._fileid_mapping[id])
 
             mapping_file = self._filename + ".fileids.json"

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -441,13 +441,12 @@ class CorporaFile(object):
                              "left!".format(fq_filename, self._relative_to))
         return rfn
 
-    def _fn_to_fq_rel(self, filename):
-        """Given a filename, returns the tuple
-           (fully-qualified filename, relative filename)
+    def _fn_to_rel(self, filename):
+        """Given a filename relative to ".", return the filename
            relative to the --relative-to path"""
         fq_filename = os.path.normcase(os.path.realpath(filename))
         relfilename = self._make_relative_filename(fq_filename)
-        return (fq_filename, relfilename)
+        return relfilename
 
     def new_file_and_fileid(self, fq_filename, file_id):
         """Add a mapping for this filename and file_id"""
@@ -491,7 +490,7 @@ class CorporaFile(object):
         else:
             filename_to = merge_to
             if self._relative_to is not None:
-                (toasfqfn, filename_to) = self._fn_to_fq_rel(filename_to)
+                filename_to = self._fn_to_rel(filename_to)
             id_to = self.fileid_of_rel_file(filename_to)
             if id_to is None:
                 raise SystemExit("Can't find merge_to {0} as file ID or file".
@@ -502,7 +501,7 @@ class CorporaFile(object):
         else:
             filename_from = merge_from
             if self._relative_to is not None:
-                (fromasfqfn, filename_from) = self._fn_to_fq_rel(filename_from)
+                filename_from = self._fn_to_rel(filename_from)
             id_from = self.fileid_of_rel_file(filename_from)
             if id_from is None:
                 raise SystemExit("Can't find merge_from {0} as file ID or file"
@@ -530,7 +529,7 @@ class CorporaFile(object):
         self._fileid_mapping_is_dirty = True
 
     def delete_file(self, filename):
-        (fq_filename, relfilename) = self._fn_to_fq_rel(filename)
+        relfilename = self._fn_to_rel(filename)
         try:
             id = self._revfileid_mapping[relfilename]
         except:
@@ -558,8 +557,8 @@ class CorporaFile(object):
         self._fileid_mapping_is_dirty = True
 
     def rename_file(self, rename_from, rename_to):
-        (from_fq, from_rel) = self._fn_to_fq_rel(rename_from)
-        (to_fq, to_rel) = self._fn_to_fq_rel(rename_to)
+        from_rel = self._fn_to_rel(rename_from)
+        to_rel = self._fn_to_rel(rename_to)
         if from_rel not in self._revfileid_mapping:
             _util.mutter(_util.VERBOSITY_NORMAL,
                          "No file ID for " + rename_from)

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -364,11 +364,11 @@ class CorporaFile(object):
             # Generate a fake file name to use to query the base dicts.
             # Since we aren't using MATCH_FILEID, the basename won't be
             # used, only the extension.
-            fakefn = "fake." + ext
+            fake_filename = "fake." + ext
             file_type_corp = self._extensions[ext]
             newtokens = []
             for t in file_type_corp._tokens:
-                if self.token_is_in_base_dict(t, fakefn, None,
+                if self.token_is_in_base_dict(t, fake_filename, None,
                                               MATCH_NATURAL | MATCH_FILETYPE):
                     file_type_corp._mark_dirty()
                 else:

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -194,7 +194,7 @@ class CorporaFile(object):
 
     """The CorporaFile manages a single file containing multiple corpora.
 
-    May include filename<->fileid mapping file too."""
+    May include filename<->file ID mapping file too."""
 
     def __init__(self, filename, base_dicts, relative_to):
         """Construct an instance from the file with the given filename.
@@ -203,7 +203,7 @@ class CorporaFile(object):
         but don't modify them or write them out.
 
         relative_to is the directory to consider paths relative to wrt
-        the fileid mapping.
+        the file ID mapping.
 
         """
         self._base_corpora_files = []
@@ -227,10 +227,10 @@ class CorporaFile(object):
             self._relative_to = os.path.normcase(os.path.realpath(relative_to))
         self._fileid_mapping = {}
         self._fileid_mapping_is_dirty = False
-        # mapping of fileid -> list-of-filenames for fileids not stored in the
-        # source files.
+        # mapping of file ID -> list-of-filenames for file IDs not
+        # stored in the source files.
         self._revfileid_mapping = {}
-        # Reverse map of the above, individual filename -> fileid
+        # Reverse map of the above, individual filename -> file ID
 
         try:
             with _util.open_with_encoding(filename, mode='r') as f:
@@ -259,22 +259,22 @@ class CorporaFile(object):
                 try:
                     self._fileid_mapping = json.load(mf)
                     _util.mutter(_util.VERBOSITY_DEBUG,
-                                 "got fileid mapping:\n{0}"
+                                 "got file ID mapping:\n{0}"
                                  .format(self._fileid_mapping))
                 except ValueError as e:
                     # Error during file creation might leave an empty file
                     # here.  Not necessarily fatal, but report it.
                     _util.mutter(_util.VERBOSITY_NORMAL,
-                                 "Couldn't load fileid mapping from {0}: {1}"
+                                 "Couldn't load file ID mapping from {0}: {1}"
                                  .format(mapping_file, e))
         except IOError as e:
             if e.errno == errno.ENOENT:
                 _util.mutter(_util.VERBOSITY_DEBUG,
-                             "No fileid mappings file {0}".format(
+                             "No file ID mappings file {0}".format(
                                  mapping_file))
             else:
                 raise SystemExit(
-                    "Can't read fileid mappings file {0}: {1}: {2}".format(
+                    "Can't read file ID mappings file {0}: {1}: {2}".format(
                         mapping_file, e.errno, e.strerror))
 
         # Build reverse map
@@ -348,7 +348,7 @@ class CorporaFile(object):
         # Only remove it when the base dict match was at least as
         # general as the corpora we're processing.  E.g., only remove
         # from our natural_dict when the word was in the natural_dict
-        # of some base_dict; not if it was in a filetype or fileid dict.
+        # of some base_dict; not if it was in a filetype or file ID dict.
         # Similarly, only remove from our filetype dict if the word was
         # in a natural_dict or the filetype dict with the same extension.
         newtokens = []
@@ -494,7 +494,7 @@ class CorporaFile(object):
                 (toasfqfn, fnto) = self._fn_to_fq_rel(fnto)
             id_to = self.fileid_of_rel_file(fnto)
             if id_to is None:
-                raise SystemExit("Can't find merge_to {0} as fileid or file".
+                raise SystemExit("Can't find merge_to {0} as file ID or file".
                                  format(merge_to))
 
         if self.fileid_exists(merge_from):
@@ -505,8 +505,8 @@ class CorporaFile(object):
                 (fromasfqfn, fnfrom) = self._fn_to_fq_rel(fnfrom)
             id_from = self.fileid_of_rel_file(fnfrom)
             if id_from is None:
-                raise SystemExit("Can't find merge_from {0} as fileid or file".
-                                 format(id_from))
+                raise SystemExit("Can't find merge_from {0} as file ID or file"
+                                 "".format(id_from))
 
         _util.mutter(_util.VERBOSITY_DEBUG,
                      "Going to merge {id_from} into {id_to}".format(
@@ -539,7 +539,7 @@ class CorporaFile(object):
             else:
                 reptstring = "{0} ({1})".format(filename, relfilename)
             _util.mutter(_util.VERBOSITY_NORMAL,
-                         "No fileid for {0}".format(reptstring))
+                         "No file ID for {0}".format(reptstring))
             return
         _util.mutter(_util.VERBOSITY_NORMAL,
                      "Removing {0} <-> {1} mappings".format(
@@ -548,10 +548,10 @@ class CorporaFile(object):
         fns = self._fileid_mapping[id]
         fns.remove(relfilename)
         if len(fns) == 0:
-            # No remaining files use this fileid.  Remove all trace of it.
+            # No remaining files use this file ID.  Remove all trace of it.
             del self._fileid_mapping[id]
 
-            # remove fileid-private dictionary from corpus.
+            # remove file ID-private dictionary from corpus.
             corpus = self._fileids[id]
             self._fileid_dicts.remove(corpus)
             del self._fileids[id]
@@ -562,7 +562,7 @@ class CorporaFile(object):
         (to_fq, to_rel) = self._fn_to_fq_rel(rename_to)
         if from_rel not in self._revfileid_mapping:
             _util.mutter(_util.VERBOSITY_NORMAL,
-                         "No fileid for " + rename_from)
+                         "No file ID for " + rename_from)
             return
 
         if to_rel in self._revfileid_mapping:
@@ -571,7 +571,7 @@ class CorporaFile(object):
         id_from = self._revfileid_mapping[from_rel]
 
         _util.mutter(_util.VERBOSITY_NORMAL,
-                     "Switching fileid {0} from {1} to {2}".format(
+                     "Switching file ID {0} from {1} to {2}".format(
                          id_from, from_rel, to_rel))
 
         fns = self._fileid_mapping[id_from]
@@ -644,7 +644,7 @@ class CorporaFile(object):
 
         if self._fileid_mapping_is_dirty:
             if self._relative_to is None:
-                raise AssertionError("fileid mapping is dirty but " +
+                raise AssertionError("file ID mapping is dirty but " +
                                      "relative_to is None")
 
             # Build an OrderedDict sorted by first filename of id, so the
@@ -674,7 +674,7 @@ class CorporaFile(object):
                     mf.write(tstr)
                 self._fileid_mapping_is_dirty = False
             except IOError as e:
-                print("Warning: unable to write fileid mapping file '{0}' "
+                print("Warning: unable to write file ID mapping file '{0}' "
                       "(reason: {1})".format(mapping_file, e))
 
         # Since we add words only to this, not to any base corpora

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -534,11 +534,11 @@ class CorporaFile(object):
             id = self._revfileid_mapping[rel_filename]
         except:
             if filename == rel_filename:
-                reptstring = filename
+                report_str = filename
             else:
-                reptstring = "{0} ({1})".format(filename, rel_filename)
+                report_str = "{0} ({1})".format(filename, rel_filename)
             _util.mutter(_util.VERBOSITY_NORMAL,
-                         "No file ID for {0}".format(reptstring))
+                         "No file ID for {0}".format(report_str))
             return
         _util.mutter(_util.VERBOSITY_NORMAL,
                      "Removing {0} <-> {1} mappings".format(

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -351,14 +351,14 @@ class CorporaFile(object):
         # of some base_dict; not if it was in a filetype or file ID dict.
         # Similarly, only remove from our filetype dict if the word was
         # in a natural_dict or the filetype dict with the same extension.
-        newtokens = []
+        new_tokens = []
         for t in self._natural_dict._tokens:
             if self.token_is_in_base_dict(t, None, None, MATCH_NATURAL):
                 # Going to change the dict, so mark it dirty
                 self._natural_dict._mark_dirty()
             else:
-                newtokens.append(t)
-        self._natural_dict._tokens = newtokens
+                new_tokens.append(t)
+        self._natural_dict._tokens = new_tokens
 
         for ext in self._extensions:
             # Generate a fake file name to use to query the base dicts.
@@ -366,14 +366,14 @@ class CorporaFile(object):
             # used, only the extension.
             fake_filename = "fake." + ext
             file_type_corp = self._extensions[ext]
-            newtokens = []
+            new_tokens = []
             for t in file_type_corp._tokens:
                 if self.token_is_in_base_dict(t, fake_filename, None,
                                               MATCH_NATURAL | MATCH_FILETYPE):
                     file_type_corp._mark_dirty()
                 else:
-                    newtokens.append(t)
-            file_type_corp._tokens = newtokens
+                    new_tokens.append(t)
+            file_type_corp._tokens = new_tokens
 
     def add_natural(self, token):
         """Add the token to the natural language corpus."""

--- a/test.cram
+++ b/test.cram
@@ -39,7 +39,7 @@ Test file ID manipulations
     $ $SCSPELL --override-dictionary tests/fileidmap/dictionary \
     >     --relative-to tests/fileidmap \
     >     --rename-file tests/fileidmap/mix2.txt tests/fileidmap/mix22.txt
-    Switching fileid d5641cfe-3574-11e6-a3a6-10ddb1d4c3d5 from mix2.txt to mix22.txt
+    Switching file ID d5641cfe-3574-11e6-a3a6-10ddb1d4c3d5 from mix2.txt to mix22.txt
     $ $SCSPELL --override-dictionary tests/fileidmap/dictionary \
     >     --relative-to tests/fileidmap \
     >     --delete-file tests/fileidmap/mix5.txt


### PR DESCRIPTION
The main change is to have "make check" spell-check scspell/*.py

The first commit changes the Makefile to include scspell/*.py (and
--relative-to .), and adds all the resulting words to the dictionary.
The rest of the commits remove a word or two at a time from the
dictionary, and fix up the code.

Except one commit that fixes a few not-words by simplifying the code:
None of CorporaFile._fn_to_fq_rel()'s callers actually used the fq
portion of the return, so I changed it to _fn_to_rel(), returning only
the relative path.  (I hadn't noticed when I factored that out that
all fo the callers generated a full-qualified path only to pass it to
make_relative().  None of them used it again after that.)

The remaining additions to the dictionary:
1. A bunch of partial words from the scspell interactive prompt
   output, such as "(N)atural" -> "atural".
2. A few deliberate misspellings used as examples, e.g. "varaible".
3. configparser, pgen, strerror: Python code.
4. typerror: part of a URL.
5. appdata: an environment variable
6. wordlist/wordlists/workaround: I don't know if these need to change.
7. fileid/fileids:

I changed comments and strings printed to the user to say "file ID".
But I left "fileid" alone in function and variable names.  Mostly
because there are so many instances.  But also because it'll have to
be in the dictionary as-is at some level, since scspell has been using
it all along as a literal string in the per-file dictionaries (even
without the .fileid.json mapping file.):

DICT_TYPE_FILEID = 'FILEID'        # Identifies file-specific dictionary

I can change the other functions and variables to use file_id if you'd
prefer.

I added per-file dictionaries using the .fileids.json file.  I could
also change them to use embedded file IDs if you'd prefer.

(For some reason, scspell/data/dictionary.txt includes filetype as a
word...)
