### PR TITLE
Change most fileid to file_id

### DIFF
--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -27,6 +27,8 @@ ontext
 rogramming
 
 FILEID: 3dadcb18-46c1-11e6-907f-843835579daa
+fileid
+fileids
 typeerror
 
 FILEID: 8bfe4130-46c1-11e6-907f-843835579daa
@@ -35,8 +37,6 @@ appdata
 NATURAL:
 american
 english
-fileid
-fileids
 github
 https
 myint

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -349,15 +349,15 @@ def handle_add(unmatched_subtokens, filename, fq_filename, file_id_ref, dicts):
                 dicts.add_natural(subtoken)
                 break
             elif offer_f and (ch == 'f'):
-                dicts.add_by_fileid(subtoken, file_id)
+                dicts.add_by_file_id(subtoken, file_id)
                 break
             elif offer_N and (ch == 'N'):
                 file_id = get_new_file_id()
                 file_id_ref[0] = file_id
                 print("New file ID {0} for {1}".format(file_id, filename),
                       file=sys.stderr)
-                dicts.new_file_and_fileid(fq_filename, file_id)
-                dicts.add_by_fileid(subtoken, file_id)
+                dicts.new_file_and_file_id(fq_filename, file_id)
+                dicts.add_by_file_id(subtoken, file_id)
                 prompt = None  # reselect prompt now that file_id is not None
                 break
     return True
@@ -537,7 +537,7 @@ def spell_check_file(filename, dicts, ignores, report_only, c_escapes):
             '(File contains id "%s".)' %
             file_id)
     else:
-        file_id = dicts.fileid_of_file(fq_filename)
+        file_id = dicts.file_id_of_file(fq_filename)
 
     file_id_ref = [file_id]  # allow for spell_check() creating a file_id
 


### PR DESCRIPTION
Remaining:
- The preexisting DICT_TYPE_FILEID.
- Its definition: FILEID.  (This is embedded in the dictionary files
  of existing scspell users, so it would be a big deal to change.)
- MATCH_FILEID, as MATCH_\* correspond to DICT_TYPE_*.
- The file ID mapping file is still named foo.fileids.json.

Move fileid and fileids from the natural-language dictionary to
_corpus.py's, as that's now the only file that contains them.
