### PR TITLE
Test interactive use

### DIFF
--- a/scspell.py
+++ b/scspell.py
@@ -155,5 +155,6 @@ def main():
                                    args.test_input)
         return 0 if okay else 1
 
+
 if __name__ == '__main__':
     sys.exit(main())

--- a/scspell.py
+++ b/scspell.py
@@ -33,6 +33,7 @@ def main():
 
     dict_group = parser.add_argument_group("dictionary file management")
     spell_group = parser.add_argument_group("spell-check control")
+    test_group = parser.add_argument_group("testing options")
 
     spell_group.add_argument(
         '--report-only', dest='report', action='store_true',
@@ -99,6 +100,10 @@ def main():
              'dictionary will be removed; this will not spell check the '
              'files')
 
+    test_group.add_argument(
+        '--test-input', action='store_true', default=False,
+        help='allow scspell to read stdin from a non-terminal.')
+
     parser.add_argument(
         '-D', '--debug', dest='debug', action='store_true',
         help='print extra debugging information')
@@ -145,9 +150,9 @@ def main():
                                    args.base_dicts,
                                    args.relative_to,
                                    args.report,
-                                   args.c_escapes)
+                                   args.c_escapes,
+                                   args.test_input)
         return 0 if okay else 1
-
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/scspell.py
+++ b/scspell.py
@@ -100,9 +100,10 @@ def main():
              'dictionary will be removed; this will not spell check the '
              'files')
 
+    #  Testing option to allow scspell to read stdin from a non-tty
     test_group.add_argument(
         '--test-input', action='store_true', default=False,
-        help='allow scspell to read stdin from a non-terminal.')
+        help=argparse.SUPPRESS)
 
     parser.add_argument(
         '-D', '--debug', dest='debug', action='store_true',

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -66,11 +66,6 @@ CONTEXT_SIZE = 4
 # Subtokens shorter than 4 characters are likely to be abbreviations
 LEN_THRESHOLD = 3
 
-# Special key codes returned from getch()
-CTRL_C = '\x03'
-CTRL_D = '\x04'
-CTRL_Z = '\x1a'
-
 USER_DATA_DIR = _portable.get_data_dir('scspell')
 DICT_DEFAULT_LOC = os.path.join(USER_DATA_DIR, 'dictionary.txt')
 SCSPELL_DATA_DIR = os.path.normpath(
@@ -329,7 +324,7 @@ def handle_add(unmatched_subtokens, filename, fq_filename, file_id_ref, dicts):
 
             print(prompt % subtoken)
             ch = _portable.getch()
-            if ch in (CTRL_C, CTRL_D, CTRL_Z):
+            if ch in (_portable.CTRL_C, _portable.CTRL_D, _portable.CTRL_Z):
                 print('User abort.')
                 sys.exit(1)
             elif ch == 'b':
@@ -393,7 +388,7 @@ def handle_failed_check_interactively(
    (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
    show (c)ontext? [i]""")
         ch = _portable.getch()
-        if ch in (CTRL_C, CTRL_D, CTRL_Z):
+        if ch in (_portable.CTRL_C, _portable.CTRL_D, _portable.CTRL_Z):
             print('User abort.')
             sys.exit(1)
         elif ch in ('i', '\r', '\n'):

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -676,7 +676,8 @@ def find_dict_file(override_dictionary):
 
 def spell_check(source_filenames, override_dictionary=None,
                 base_dicts=[],
-                relative_to=None, report_only=False, c_escapes=True):
+                relative_to=None, report_only=False, c_escapes=True,
+                test_input=False):
     """Run the interactive spell checker on the set of source_filenames.
 
     If override_dictionary is provided, it shall be used as a dictionary
@@ -685,6 +686,9 @@ def spell_check(source_filenames, override_dictionary=None,
     :returns: None
 
     """
+    if test_input:
+        _portable.allow_non_terminal_input()
+
     dict_file = find_dict_file(override_dictionary)
 
     okay = True

--- a/scspell/_portable.py
+++ b/scspell/_portable.py
@@ -58,7 +58,10 @@ except ImportError:
 
 def allow_non_terminal_input():
     def testing_getch():
-        return sys.stdin.read(1)
+        s = sys.stdin.read(1)
+        if s == "":
+            return CTRL_D
+        return s
     global getch
     getch = testing_getch
 

--- a/scspell/_portable.py
+++ b/scspell/_portable.py
@@ -26,18 +26,20 @@ from __future__ import unicode_literals
 import os
 import sys
 
+getch = None
 # Cross-platform version of getch()
 try:
     import msvcrt
 
-    def getch():
+    def msvcrt_getch():
         return msvcrt.getch()
+    getch = msvcrt_getch
 
 except ImportError:
     import tty
     import termios
 
-    def getch():
+    def termios_getch():
         fd = sys.stdin.fileno()
         old_settings = termios.tcgetattr(fd)
         try:
@@ -46,6 +48,14 @@ except ImportError:
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
         return ch
+    getch = termios_getch
+
+
+def allow_non_terminal_input():
+    def testing_getch():
+        return sys.stdin.read(1)
+    global getch
+    getch = testing_getch
 
 
 def get_data_dir(prog_name):

--- a/scspell/_portable.py
+++ b/scspell/_portable.py
@@ -26,6 +26,11 @@ from __future__ import unicode_literals
 import os
 import sys
 
+# Special key codes returned from getch()
+CTRL_C = '\x03'
+CTRL_D = '\x04'
+CTRL_Z = '\x1a'
+
 getch = None
 # Cross-platform version of getch()
 try:

--- a/test.cram
+++ b/test.cram
@@ -84,3 +84,66 @@ Filter out builtin-base-dict from base-dictionary-2
     $ $SCSPELL --override-dictionary $T/base-dictionary-2 \
     >     --use-builtin-base-dict --filter-out-base-dicts
     $ diff -u $T/base-dictionary-2 $T/base-dictionary-2.filtered
+
+Test interactive use, using --test-input instead of --report-only
+
+    $ SCSPELL="$TESTDIR/scspell.py --test-input"
+
+ replace bakingsoda -> barking soda
+ ignore cromulent
+ add-natural embiggen
+ show context of yavin
+ replace/cancel-via-enter yavin
+ add/back yavin
+ ignore yavin
+
+    $ (echo rbarking soda; echo iancr; echo abi) | \
+    > $SCSPELL --use-builtin-base-dict --override-dictionary $T/newdict \
+    > $T/testfile
+    Warning: unable to read dictionary file 'tests/basedicts/newdict' (reason: [Errno 2] No such file or directory: 'tests/basedicts/newdict')
+    Continuing with empty natural dictionary
+    
+    tests/basedicts/testfile:1: Unmatched 'bakingsoda' --> {bakingsoda}
+       (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
+       show (c)ontext? [i]
+          Replacement text for 'bakingsoda': 
+    tests/basedicts/testfile:2: Unmatched 'cromulent' --> {cromulent}
+       (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
+       show (c)ontext? [i]
+    
+    tests/basedicts/testfile:3: Unmatched 'embiggen' --> {embiggen}
+       (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
+       show (c)ontext? [i]
+          Subtoken 'embiggen':
+             (b)ack, (i)gnore, add to (n)atural language dictionary [i]
+    
+    tests/basedicts/testfile:3: Unmatched 'yavin' --> {yavin}
+       (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
+       show (c)ontext? [i]
+       1: hoth apple barking soda
+       2: perfectly cromulent
+       3: also embiggen yavin
+       4: 
+    
+       (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
+       show (c)ontext? [i]
+          Replacement text for 'yavin':       (Canceled.)
+    
+       (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
+       show (c)ontext? [i]
+          Subtoken 'yavin':
+             (b)ack, (i)gnore, add to (n)atural language dictionary [i]
+             (Canceled.)
+    
+       (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
+       show (c)ontext? [i]
+    
+    [1]
+    $ cat $T/testfile
+    hoth apple barking soda
+    perfectly cromulent
+    also embiggen yavin
+    $ cat $T/newdict
+    NATURAL:
+    embiggen
+    


### PR DESCRIPTION
This adds tests of some interactive spellchecking (add/replace/ignore/context).

I'm not happy with it yet; do you think it's worth pursuing?

In order to accept input from a non-tty stdin, I had to do something that seems pretty gross to _portable.py's getch().  It seems unclean in principle, and fails abysmally when the provided stdin ends before scspell's done reading from it.  Also, scspell's interactive prompting is kind of chatty, to test.cram's detriment.  I don' t know if it would be worth something like adding a --no-prompt testing option just to make that cleaner.
