### PR TITLE
Add an osx run to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,27 @@
 language: python
 
-python:
-    - "2.7"
-    - "3.2"
-    - "3.3"
-    - "3.4"
-    - "3.5"
+matrix:
+    include:
+      - python: "2.7"
+        os: linux
+      - python: "3.2"
+        os: linux
+      - python: "3.3"
+        os: linux
+      - python: "3.4"
+        os: linux
+      - python: "3.5"
+        os: linux
+      - os: osx
+        language: generic
 
 before_install:
-    - pip install --quiet git+https://github.com/myint/cram.git
+   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo pip install --quiet git+https://github.com/myint/cram.git || cat /Users/travis/Library/logs/pip.log; fi
+   - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then      pip install --quiet git+https://github.com/myint/cram.git; fi
 
 install:
-    - python setup.py --quiet install
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo python setup.py --quiet install; fi
+    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then      python setup.py --quiet install; fi
 
 script:
     - cram --indent=4 test.cram


### PR DESCRIPTION
This takes a bit of hacking around, as travis doesn't officially
support python progjects on osx: travis-ci/travis-ci/issues/2312

Copy the approach used in ssokolow/get_user_headers/issues/3

This only runs one version of python, because it ends up with whatever
system python happens to be installed on the osx worker.

The osx workers require "sudo" on the pip install lines.
