### PR TITLE
Exit with status code 2 when user hits ^C

### DIFF
--- a/.scspell/dictionary.txt
+++ b/.scspell/dictionary.txt
@@ -17,6 +17,7 @@ mispeld
 nworld
 ontext
 rogramming
+sigint
 varaible
 
 FILEID: a5ba480a-46bf-11e6-907f-843835579daa

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,11 @@ prompted with the following options for every subtoken:
     add to (n)atural language dictionary
         Add this subtoken to the natural language dictionary.
 
+If scspell finds no unknown tokens, it exits with exit status 0.  If
+there were unknown tokens, it exits with exit status 1.  If it
+terminates in response to a (handled) signal such as a SIGINT from ^C,
+it exits with exit status 2.
+
 
 Spell-checking Options
 ----------------------

--- a/__main__.py
+++ b/__main__.py
@@ -6,4 +6,7 @@ import scspell
 
 
 if __name__ == '__main__':
-    sys.exit(scspell.main())
+    try:
+        sys.exit(scspell.main())
+    except KeyboardInterrupt:
+        sys.exit(2)

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -328,8 +328,7 @@ def handle_add(unmatched_subtokens, filename, fq_filename, file_id_ref, dicts):
             print(prompt % subtoken)
             ch = _portable.getch()
             if ch in (_portable.CTRL_C, _portable.CTRL_D, _portable.CTRL_Z):
-                print('User abort.')
-                sys.exit(1)
+                sys.exit(2)
             elif ch == 'b':
                 print("""\
          (Canceled.)\n""")
@@ -392,8 +391,7 @@ def handle_failed_check_interactively(
    show (c)ontext? [i]""")
         ch = _portable.getch()
         if ch in (_portable.CTRL_C, _portable.CTRL_D, _portable.CTRL_Z):
-            print('User abort.')
-            sys.exit(1)
+            sys.exit(2)
         elif ch in ('i', '\r', '\n'):
             break
         elif ch == 'I':


### PR DESCRIPTION
This allows a script that calls scspell to distinguish between scspell
finding a mispelled word, and the user trying to interrupt the script.

e.g.
    scspell file1
    if [ $? == 2 ]; then
       exit 1
    fi
    scspell file2
    ...

Remove the "User abort" prints.  Most programs just exit when the user
hits ^C; there's no reason to do otherwise.

Update the README to document the exit codes.
