### PR TITLE
Add '--add-to-dict' functionality.

### DIFF
--- a/test.cram
+++ b/test.cram
@@ -89,6 +89,32 @@ Filter out builtin-base-dict from base-dictionary-2
     >     --use-builtin-base-dict --filter-out-base-dicts
     $ diff -u $T/base-dictionary-2 $T/base-dictionary-2.filtered
 
+Test add file to dictionary from command line
+
+    $ SCSPELL="python $TESTDIR --override-dictionary tests/basedicts/addtodict"
+
+    $ $SCSPELL --add-to-dict p additional file.ex
+    Dictionary for file extension '.ex' not found.
+    $ $SCSPELL --add-to-dict natural myfancyword
+    $ $SCSPELL --add-to-dict n special
+    $ $SCSPELL --add-to-dict programming dizzy file.py
+    $ $SCSPELL --add-to-dict p juicy  py
+    $ $SCSPELL --add-to-dict file unique file.py --relative-to .
+    New file ID .* for file.py (re)
+
+    $ cat tests/basedicts/addtodict
+    FILETYPE: Python; .py
+    dizzy
+    juicy
+    
+    FILEID: .* (re)
+    unique
+    
+    NATURAL:
+    myfancyword
+    special
+    
+
 Test interactive use, using --test-input instead of --report-only
 
     $ SCSPELL="python $TESTDIR --test-input"

--- a/tests/basedicts/addtodict
+++ b/tests/basedicts/addtodict
@@ -1,0 +1,3 @@
+FILETYPE: Python; .py
+
+NATURAL:


### PR DESCRIPTION
Adds possibility to add word to dictionary from command line #19.

It adds `--add-to-dict DICT_TYPE WORD` agument.

`DICT_TYPE` can be one of:
    - `n` or `natural`
    - `p` or `programming`
    - `f` or `file`

When `programming` or `file` is used it requires to provide file positional argument as well.

Any thoughts?