### PR TITLE
Fix getch issue on Windows

### DIFF
--- a/scspell/_portable.py
+++ b/scspell/_portable.py
@@ -37,7 +37,7 @@ try:
     import msvcrt
 
     def msvcrt_getch():
-        return msvcrt.getch()
+        return msvcrt.getwch()
     getch = msvcrt_getch
 
 except ImportError:


### PR DESCRIPTION
 - msvcrt.getch returns a byte instead of a string so any of the
   comparisons to strings always fail.  Changing getch to getwch
   which returns a string and fixes this.