### PR TITLE
Fix tokenising when using using more than just a-zA-Z

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /MANIFEST
 __pycache__/
 *.pyc
+test.cram.err

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -25,7 +25,7 @@ from __future__ import unicode_literals
 
 import argparse
 import os
-import re
+import regex
 import sys
 import shutil
 import uuid
@@ -78,22 +78,22 @@ SCSPELL_CONF = os.path.join(USER_DATA_DIR, 'scspell.conf')
 # Treat anything alphanumeric as a token of interest, as long as it is not
 # immediately preceded by a single backslash.  (The string "\ntext" should
 # match on "text" rather than "ntext".)
-C_ESCAPE_TOKEN_REGEX = re.compile(r'(?<![^\\]\\)\w+')
+C_ESCAPE_TOKEN_REGEX = regex.compile(r'(?<![^\\]\\)\w+')
 
 # \ is not a character escape in e.g. LaTeX
-TOKEN_REGEX = re.compile(r'\w+')
+TOKEN_REGEX = regex.compile(r'\w+')
 
 # Hex digits will be treated as a special case, because they can look like
 # word-like even though they are actually numeric
-HEX_REGEX = re.compile(r'0x[0-9a-fA-F]+')
+HEX_REGEX = regex.compile(r'0x[0-9a-fA-F]+')
 
 # We assume that tokens will be split using either underscores,
 # digits, or camelCase conventions (or both)
-US_REGEX = re.compile(r'[_\d]+')
-CAMEL_WORD_REGEX = re.compile(r'([A-Z][a-z]*)')
+US_REGEX = regex.compile(r'[_\d]+')
+CAMEL_WORD_REGEX = regex.compile(r'([[:upper:]][[:lower:]]*)')
 
 # File-id specifiers take this form
-FILE_ID_REGEX = re.compile(r'scspell-id:[ \t]*([a-zA-Z0-9_\-]+)')
+FILE_ID_REGEX = regex.compile(r'scspell-id:[ \t]*([a-zA-Z0-9_\-]+)')
 
 
 class MatchDescriptor(object):
@@ -384,7 +384,7 @@ def handle_failed_check_interactively(
     print("%s:%u: Unmatched '%s' --> {%s}" %
           (filename, match_desc.get_line_num(), token,
            ', '.join([st for st in unmatched_subtokens])))
-    MATCH_REGEX = re.compile(re.escape(match_desc.get_token()))
+    MATCH_REGEX = regex.compile(regex.escape(match_desc.get_token()))
     while True:
         print("""\
    (i)gnore, (I)gnore all, (r)eplace, (R)eplace all, (a)dd to dictionary, or
@@ -405,7 +405,7 @@ def handle_failed_check_interactively(
       (Canceled.)\n""")
             else:
                 ignores.add(replacement.lower())
-                tail = re.sub(
+                tail = regex.sub(
                     MATCH_REGEX, replacement, match_desc.get_remainder(),
                     1 if ch == 'r' else 0)
                 print()
@@ -771,7 +771,7 @@ def add_to_dict(dictionary_type, word, files=[],
             dicts.add_by_file_id(word, file_id)
 
         elif dictionary_type[0] == 'p':
-            ext = re.sub(r'.*\.', '.', '.{}'.format(files[0].lower()))
+            ext = regex.sub(r'.*\.', '.', '.{}'.format(files[0].lower()))
             if not dicts.add_by_extension(word, ext):
                 print("Dictionary for file extension '{}' not found."
                       .format(ext), file=sys.stderr)

--- a/scspell/_corpus.py
+++ b/scspell/_corpus.py
@@ -29,7 +29,7 @@ import errno
 import io
 import json
 import os
-import re
+import regex
 import sys
 from bisect import bisect_left
 from . import _util
@@ -41,7 +41,7 @@ DICT_TYPE_FILEID = 'FILEID'        # Identifies file-specific dictionary
 
 
 # Valid file ID strings take this form
-FILE_ID_REGEX = re.compile(r'[a-zA-Z0-9_\-]+')
+FILE_ID_REGEX = regex.compile(r'[a-zA-Z0-9_\-]+')
 
 
 MATCH_NATURAL = 0x1

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setuptools.setup(
         'Topic :: Software Development',
         'Topic :: Text Processing :: Linguistic',
         'Topic :: Utilities'],
-    platforms=['any']
+    platforms=['any'],
+    install_requires=['regex']
 )

--- a/test.cram
+++ b/test.cram
@@ -16,7 +16,6 @@ Test okay file.
     $ echo 'This is okay.' > good.txt
     $ $SCSPELL good.txt
 
-
 Test file with --override-dictionary and a fileid mapping entry
 
     $ cp -a "$TESTDIR/tests" .
@@ -25,6 +24,14 @@ Test file with --override-dictionary and a fileid mapping entry
     >     'tests/fileidmap/inputfile.txt' 'tests/fileidmap/inputfile2.txt'
     tests/fileidmap/inputfile.txt:3: 'soem' not found in dictionary (from token 'soem')
     tests/fileidmap/inputfile2.txt:4: 'soem' not found in dictionary (from token 'soem')
+    [1]
+
+Test spelling mistake with diacritics.
+
+    $ $SCSPELL 'tests/basedicts/unicode-testfile'
+    tests/basedicts/unicode-testfile:1: 'b\xe4dly' not found in dictionary (from token 'B\xe4dly')
+    tests/basedicts/unicode-testfile:1: '\xe1lmost' not found in dictionary (from token '\xc1lmost')
+    tests/basedicts/unicode-testfile:1: '\xe7\xe5m\xe9l', '\xe7\xe4se' were not found in the dictionary (from token '\xc7\xe5m\xe9l\xc7\xe4se')
     [1]
 
 Test file ID manipulations

--- a/tests/basedicts/unicode-testfile
+++ b/tests/basedicts/unicode-testfile
@@ -1,0 +1,1 @@
+Bädly Álmost ÇåmélÇäse


### PR DESCRIPTION
Previously: `Händler` would be tokenized as `ndler` or `ändler` depending on python version
Rather than the expected `händler`

Solution: use `regexp` rather than `re`.
This gives us the ability to use unicode character clasess such as `[[:upper:]]` and `[[:lower:]]`

Fixes #35

I'm usually a ruby developer not a python developer I don't know how to get the regex library working on 2.7 or how to compare the test strings in a unicode-aware way (they're different on my mac vs on travis, if one passes the other fails)

But it mostly works