### PR TITLE
add optional argument to specify additional extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ python:
 
 before_install:
    - pip install cram
+   - pip install pytest
 
 install:
     - python setup.py install
 
 script:
     - cram --indent=4 test.cram
+    - pytest tests/

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -673,7 +673,8 @@ def find_dict_file(override_dictionary):
 def spell_check(source_filenames, override_dictionary=None,
                 base_dicts=[],
                 relative_to=None, report_only=False, c_escapes=True,
-                test_input=False):
+                test_input=False,
+                additional_extensions=None):
     """Run the interactive spell checker on the set of source_filenames.
 
     If override_dictionary is provided, it shall be used as a dictionary
@@ -689,6 +690,8 @@ def spell_check(source_filenames, override_dictionary=None,
 
     okay = True
     with CorporaFile(dict_file, base_dicts, relative_to) as dicts:
+        for extension in (additional_extensions or []):
+            dicts.register_extension(*extension)
         ignores = set()
         for f in source_filenames:
             if not spell_check_file(f, dicts, ignores, report_only, c_escapes):

--- a/tests/fileidmap/custom.ext
+++ b/tests/fileidmap/custom.ext
@@ -1,0 +1,2 @@
+def func(**kwargs):
+    pass

--- a/tests/test_additional_extensions.py
+++ b/tests/test_additional_extensions.py
@@ -1,0 +1,15 @@
+import os
+
+from scspell import spell_check
+
+
+def test_additional_extensions():
+    source_filenames = [os.path.join(
+        os.path.dirname(__file__), 'fileidmap', 'custom.ext')]
+    result = spell_check(source_filenames, report_only=True)
+    assert result is False
+
+    result = spell_check(
+        source_filenames, report_only=True,
+        additional_extensions=[('.ext', 'Python')])
+    assert result is True


### PR DESCRIPTION
This enables to call `spell_check()` and e.g. pass additional extensions like `additional_extensions=[('', 'Python')]` to the `CorporaFile`.