### PR TITLE
add Report class to optionally collect and classify unmatched subtokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ python:
 
 before_install:
    - pip install cram
+   - pip install pytest
 
 install:
     - python setup.py install
 
 script:
     - cram --indent=4 test.cram
+    - pytest tests/

--- a/tests/test_callable_report.py
+++ b/tests/test_callable_report.py
@@ -1,0 +1,16 @@
+import os
+
+from scspell import Report
+from scspell import spell_check
+
+
+def test_additional_extensions():
+    source_filenames = [os.path.join(
+        os.path.dirname(__file__), 'fileidmap', 'inputfile.txt')]
+    report = Report(('soem', 'other'))
+    result = spell_check(source_filenames, report_only=report)
+    assert result is False
+
+    # 'other' was not found in the input
+    assert report.found_known_words == {'soem'}
+    assert report.unknown_words == {'wrods', 'finially'}


### PR DESCRIPTION
The second part of the diff enables to pass not only a boolean as the `report_only` argument but any callable. If the parameter is a callable it is invoked instead of the default function `report_failed_check`.

The first part of the diff adds a `Report` class which acts as a functor which can be passed as the  `report_only` argument. The instance collects all unmatched subtokens and classifies them according to a list of known words (this could e.g. be a custom dictionary).