### PR TITLE
Add inline directive to ignore a given line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,14 @@ Spell-checking Options
  see the tokens "``lpha``", "``eta``", "``amma``", and "``elta``".
 
 
+--disable-nospell\
+ By default, **scspell** will ignore any lines in a file which contain the
+ string ``# nospell``. This inline directive allows users to select lines to
+ ommit from spell checking at their discretion.
+
+ The ``--disable-nospell`` will disable this functionality, and ``# nospell``
+ directives will be ignored by **scspell**.
+
 Creating File IDs
 -----------------
 

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -95,6 +95,9 @@ CAMEL_WORD_REGEX = re.compile(r'([A-Z][a-z]*)')
 # File-id specifiers take this form
 FILE_ID_REGEX = re.compile(r'scspell-id:[ \t]*([a-zA-Z0-9_\-]+)')
 
+# No spell-checking directive (ignores line)
+NO_SPELL = "# nospell"
+
 
 class MatchDescriptor(object):
 
@@ -579,6 +582,10 @@ def spell_check_file(filename, dicts, ignores, report_only, c_escapes):
         token_regex = C_ESCAPE_TOKEN_REGEX
     else:
         token_regex = TOKEN_REGEX
+
+    # Remove lines with the '# nospell' directive
+    source_text = "".join(
+        [l for l in source_text.splitlines(keepends=True) if NO_SPELL not in l])
 
     # Search for tokens to spell-check
     data = source_text

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -545,7 +545,8 @@ def spell_check_token(
         False)
 
 
-def spell_check_file(filename, dicts, ignores, report_only, c_escapes):
+def spell_check_file(filename, dicts, ignores, report_only, c_escapes,
+                     disable_nospell):
     """Spell check a single file.
 
     :param filename: name of the file to check
@@ -583,9 +584,12 @@ def spell_check_file(filename, dicts, ignores, report_only, c_escapes):
     else:
         token_regex = TOKEN_REGEX
 
-    # Remove lines with the '# nospell' directive
-    source_text = "".join(
-        [l for l in source_text.splitlines(keepends=True) if NO_SPELL not in l])
+    if not disable_nospell:
+        # Remove lines with the '# nospell' directive
+        source_text = "".join(
+            [l for l in source_text.splitlines(keepends=True)
+             if NO_SPELL not in l]
+        )
 
     # Search for tokens to spell-check
     data = source_text
@@ -718,7 +722,7 @@ def find_dict_file(override_dictionary):
 def spell_check(source_filenames, override_dictionary=None,
                 base_dicts=[],
                 relative_to=None, report_only=False, c_escapes=True,
-                test_input=False,
+                disable_nospell=False, test_input=False,
                 additional_extensions=None):
     """Run the interactive spell checker on the set of source_filenames.
 
@@ -739,7 +743,8 @@ def spell_check(source_filenames, override_dictionary=None,
             dicts.register_extension(*extension)
         ignores = set()
         for f in source_filenames:
-            if not spell_check_file(f, dicts, ignores, report_only, c_escapes):
+            if not spell_check_file(f, dicts, ignores, report_only, c_escapes,
+                                    disable_nospell):
                 okay = False
     return okay
 
@@ -852,6 +857,10 @@ def main():
         '--no-c-escapes', dest='c_escapes',
         action='store_false', default=True,
         help='treat \\label as label, for e.g. LaTeX')
+    spell_group.add_argument(
+        '--disable-nospell', action='store_true',
+        help='Disable the effect of "# nospell". This will spell check lines '
+             'with "# nospell" in.')
 
     dict_group.add_argument(
         '--override-dictionary', dest='override_filename',

--- a/scspell/__init__.py
+++ b/scspell/__init__.py
@@ -587,8 +587,7 @@ def spell_check_file(filename, dicts, ignores, report_only, c_escapes,
     if not disable_nospell:
         # Remove lines with the '# nospell' directive
         source_text = "".join(
-            [l for l in source_text.splitlines(keepends=True)
-             if NO_SPELL not in l]
+            [l for l in source_text.splitlines(True) if NO_SPELL not in l]
         )
 
     # Search for tokens to spell-check


### PR DESCRIPTION
This implements support for ignoring given lines of a source file with an inline directive `# nospell`, similar to Flake8's `# noqa`.

The spell checker will ignore any line containing the string `# nospell`, this is useful for content such as URLs, base-64 encoded strings, and other tokens which are neither natural language nor syntactic keywords.

We implemented this because our custom dictionary was becoming large and unmaintainable. Issue https://github.com/myint/scspell/issues/44 describes a very similar use case.

The `--disable-nospell` flag can be used to disable this functionality.

